### PR TITLE
Add basic support for object and doc token streams

### DIFF
--- a/Fauna.Test/Serialization/Utf8FaunaReader.Tests.cs
+++ b/Fauna.Test/Serialization/Utf8FaunaReader.Tests.cs
@@ -1,3 +1,7 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using Fauna.Serialization;
 using NUnit.Framework;
 
 namespace Fauna.Test.Serialization;
@@ -6,4 +10,79 @@ namespace Fauna.Test.Serialization;
 public class Utf8FaunaReaderTests
 {
 
+    [Test]
+    public void ReadDocumentTokens()
+    {
+        const string s = """
+                         {
+                            "@doc": {
+                                "id": "123",
+                                "data": { "foo": "bar" }
+                            }
+                         }
+                         """;
+        var bytes = Encoding.UTF8.GetBytes(s);
+        var reader = new Utf8FaunaReader(new ReadOnlySequence<byte>(bytes));
+        reader.Read();
+        Assert.AreEqual(TokenType.StartDocument, reader.TokenType);
+        reader.Read();
+        Assert.AreEqual(TokenType.FieldName, reader.TokenType);
+        Assert.AreEqual("id", reader.GetString());
+        reader.Read();
+        Assert.AreEqual(TokenType.String, reader.TokenType);
+        Assert.AreEqual("123", reader.GetString());
+        reader.Read();
+        Assert.AreEqual(TokenType.FieldName, reader.TokenType);
+        Assert.AreEqual("data", reader.GetString());
+        reader.Read();
+        Assert.AreEqual(TokenType.StartObject, reader.TokenType);
+        reader.Read();
+        Assert.AreEqual(TokenType.FieldName, reader.TokenType);
+        Assert.AreEqual("foo", reader.GetString());
+        reader.Read();
+        Assert.AreEqual(TokenType.String, reader.TokenType);
+        Assert.AreEqual("bar", reader.GetString());
+        reader.Read();
+        Assert.AreEqual(TokenType.EndObject, reader.TokenType);
+        reader.Read();
+        Assert.AreEqual(TokenType.EndDocument, reader.TokenType);
+        Assert.False(reader.Read());
+    }
+    
+    [Test]
+    public void ReadObjectTokens()
+    {
+        const string s = """
+                         {
+                            "foo": "bar",
+                            "data": { "baz": "luhrmann" }
+                         }
+                         """;
+        var bytes = Encoding.UTF8.GetBytes(s);
+        var reader = new Utf8FaunaReader(new ReadOnlySequence<byte>(bytes));
+        reader.Read();
+        Assert.AreEqual(TokenType.StartObject, reader.TokenType);
+        reader.Read();
+        Assert.AreEqual(TokenType.FieldName, reader.TokenType);
+        Assert.AreEqual("foo", reader.GetString());
+        reader.Read();
+        Assert.AreEqual(TokenType.String, reader.TokenType);
+        Assert.AreEqual("bar", reader.GetString());
+        reader.Read();
+        Assert.AreEqual(TokenType.FieldName, reader.TokenType);
+        Assert.AreEqual("data", reader.GetString());
+        reader.Read();
+        Assert.AreEqual(TokenType.StartObject, reader.TokenType);
+        reader.Read();
+        Assert.AreEqual(TokenType.FieldName, reader.TokenType);
+        Assert.AreEqual("baz", reader.GetString());
+        reader.Read();
+        Assert.AreEqual(TokenType.String, reader.TokenType);
+        Assert.AreEqual("luhrmann", reader.GetString());
+        reader.Read();
+        Assert.AreEqual(TokenType.EndObject, reader.TokenType);
+        reader.Read();
+        Assert.AreEqual(TokenType.EndObject, reader.TokenType);
+        Assert.False(reader.Read());
+    }
 }

--- a/Fauna/Serialization/SerializationException.cs
+++ b/Fauna/Serialization/SerializationException.cs
@@ -1,0 +1,10 @@
+using System.Transactions;
+
+namespace Fauna.Serialization;
+
+public class SerializationException: Exception
+{
+    public SerializationException(string? message) : base(message)
+    {
+    }
+}

--- a/Fauna/Serialization/TokenType.cs
+++ b/Fauna/Serialization/TokenType.cs
@@ -1,7 +1,7 @@
 namespace Fauna.Serialization;
 
 
-public enum FaunaTokenType
+public enum TokenType
 {
     /// <summary>There is no value. This is the default token type if no data has been read by the <see cref="T:Fauna.Serialization.Utf8FaunaReader" />.</summary>
     None,
@@ -10,6 +10,12 @@ public enum FaunaTokenType
     StartObject,
     /// <summary>The token type is the end of a Fauna object.</summary>
     EndObject,
+    
+    /// <summary>The token type is the start of an escaped Fauna object. This is only used internally.</summary>
+    StartEscapedObject,
+    
+    /// <summary>The token type is the start of a tagged Fauna object. This is only used internally.</summary>
+    StartTaggedObject,
     
     /// <summary>The token type is the start of a Fauna array.</summary>
     StartArray,

--- a/Fauna/Serialization/Utf8FaunaReader.cs
+++ b/Fauna/Serialization/Utf8FaunaReader.cs
@@ -6,30 +6,156 @@ namespace Fauna.Serialization;
 
 public ref struct Utf8FaunaReader
 {
-
     private Utf8JsonReader _json;
-    
-    public FaunaTokenType FaunaTokenType { get; }
+    private readonly Stack<TokenType> _tokenStack = new();
+    private bool _bufferedStartObject = false;
+
+    public TokenType TokenType { get; private set; }
     
     public Utf8FaunaReader(ReadOnlySequence<byte> bytes)
     {
-        FaunaTokenType = FaunaTokenType.None;
+        TokenType = TokenType.None;
         _json = new Utf8JsonReader(bytes);
     }
 
     public bool Read()
     {
-        throw new NotImplementedException();
+        try
+        {
+            if (_bufferedStartObject)
+            {
+                _bufferedStartObject = false;
+                TokenType = TokenType.FieldName;
+                return true;
+            }
+            
+            if (!_json.Read())
+            {
+                return false;
+            }
+            
+            switch (_json.TokenType)
+                {
+                    case JsonTokenType.PropertyName:
+                    {
+                        TokenType = TokenType.FieldName;
+                        break;
+                    }
+                    case JsonTokenType.Number:
+                    {
+                        throw new NotImplementedException();
+                    }
+                    case JsonTokenType.None:
+                        break;
+                    case JsonTokenType.StartObject:
+                        // advance to determine if it's a tagged type
+                        _json.Read();
+                        
+                        switch (_json.GetString())
+                        {
+                            case "@date":
+                                throw new NotImplementedException();
+                            case "@doc":
+                                TokenType = TokenType.StartDocument;
+                                _tokenStack.Push(TokenType.StartTaggedObject);
+                                _tokenStack.Push(TokenType.StartDocument);
+                                // advance through JsonTokenType.StartObject
+                                return _json.Read();
+                            case "@double":
+                                throw new NotImplementedException();
+                            case "@int":
+                                throw new NotImplementedException();
+                            case "@long":
+                                throw new NotImplementedException();
+                            case "@mod":
+                                throw new NotImplementedException();
+                            case "@object":
+                                throw new NotImplementedException();
+                            case "@ref":
+                                throw new NotImplementedException();
+                            case "@set":
+                                throw new NotImplementedException();
+                            case "@time":
+                                throw new NotImplementedException();
+                            default:
+                                _bufferedStartObject = true;
+                                _tokenStack.Push(TokenType.StartObject);
+                                TokenType = TokenType.StartObject;
+                                break;
+                        }
+                        
+                        break;
+                    case JsonTokenType.EndObject:
+                        switch (_tokenStack.Pop())
+                        {
+                            case TokenType.StartDocument:
+                                TokenType = TokenType.EndDocument;
+                                Read();
+                                break;
+                            case TokenType.StartSet:
+                                TokenType = TokenType.EndSet;
+                                Read();
+                                break;
+                            case TokenType.StartRef:
+                                TokenType = TokenType.EndRef;
+                                Read();
+                                break;
+                            case TokenType.StartObject:
+                            case TokenType.StartEscapedObject:
+                                TokenType = TokenType.EndObject;
+                                break;
+                            case TokenType.StartTaggedObject:
+                                // we've advanced the Read() to pop this. Drop it on the floor.
+                                break;
+                            default:
+                                throw new SerializationException("This is a bug. Unhandled object wrapper token.");
+                        }
+
+                        break;
+                    case JsonTokenType.StartArray:
+                        break;
+                    case JsonTokenType.EndArray:
+                        break;
+                    case JsonTokenType.Comment:
+                        break;
+                    case JsonTokenType.String:
+                        TokenType = TokenType.String;
+                        break;
+                    case JsonTokenType.True:
+                        TokenType = TokenType.True;
+                        break;
+                    case JsonTokenType.False:
+                        TokenType = TokenType.False;
+                        break;
+                    case JsonTokenType.Null:
+                        TokenType = TokenType.Null;
+                        break;
+                }
+
+            return true;
+        }
+        catch (JsonException e)
+        {
+            throw new SerializationException(e.Message);
+        }
     }
     
-    public bool Skip()
+    public void Skip()
     {
         throw new NotImplementedException();
     }
 
-    public string GetString()
+    public string? GetString()
     {
-        throw new NotImplementedException(); 
+        if (_bufferedStartObject)
+        {
+            // if we buffered StartObject, behave like we're at StartObject.
+            // TODO: Write a nice message.
+            throw new InvalidOperationException();
+        }
+        
+        // TODO: Wrap these errors in our own.
+        return _json.GetString();
     }
     
     public bool GetBoolean()


### PR DESCRIPTION
This adds some body to the token stream.

* Stream `@doc` tokens
* Stream object tokens
* Sets up a framework to implement other tagged types and handle escaping


Out of scope:
* Escaped objects
* Most types
* Arrays and things dependent on arrays.