### PR TITLE
require switch expressions to be exhaustive (but exclude unnamed enums)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.cs]
+# Require switch expressions to be exhaustive
+dotnet_diagnostic.CS8509.severity = error
+# Don't require switch expressions to cover unamed enum variants
+dotnet_diagnostic.CS8524.severity = none


### PR DESCRIPTION
I'm sure there's actually more .editorconfig stuff we could add, but found this.