### PR TITLE
Run dotnet format on build

### DIFF
--- a/Fauna.Test/Fauna.Test.csproj
+++ b/Fauna.Test/Fauna.Test.csproj
@@ -17,4 +17,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="dotnet format --severity warn --verbosity diagnostic" />
+  </Target>
+
 </Project>

--- a/Fauna/Fauna.csproj
+++ b/Fauna/Fauna.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="dotnet format --severity warn --verbosity diagnostic" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
If this gets too expensive we can remove it, but for now this is a viable option for formatting before committing.