### PR TITLE
Test project build for .NET 6.0 and 8.0, add 6.0 to test matrix

### DIFF
--- a/.github/workflows/pr_validate.yml
+++ b/.github/workflows/pr_validate.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: [ '8.0.x' ]
+        dotnet-version: [ '6.0.x', '8.0.x' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/Fauna.Test/Fauna.Test.csproj
+++ b/Fauna.Test/Fauna.Test.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Fauna.Test/Serialization/Serializer.Classes.Tests.cs
+++ b/Fauna.Test/Serialization/Serializer.Classes.Tests.cs
@@ -61,17 +61,17 @@ public partial class SerializerTests
 
         // Date conversions
         [Field("datetime_to_date", FaunaType.Date)]
-        public DateTime? DateTimeToDate { get; set; } = new DateTime(2023, 12, 13, 12, 12, 12, 1, 1, DateTimeKind.Utc);
+        public DateTime? DateTimeToDate { get; set; } = DateTime.Parse("2023-12-13T12:12:12.001001Z");
         [Field("dateonly_to_date", FaunaType.Date)]
         public DateOnly? DateOnlyToDate { get; set; } = new DateOnly(2023, 12, 13);
         [Field("datetimeoffset_to_date", FaunaType.Date)]
-        public DateTimeOffset? DateTimeOffsetToDate { get; set; } = new DateTimeOffset(new DateTime(2023, 12, 13, 12, 12, 12, 1, 1, DateTimeKind.Utc));
+        public DateTimeOffset? DateTimeOffsetToDate { get; set; } = DateTimeOffset.Parse("2023-12-13T12:12:12.001001Z");
 
         // Time conversions
         [Field("datetime_to_time", FaunaType.Time)]
-        public DateTime? DateTimeToTime { get; set; } = new DateTime(2023, 12, 13, 12, 12, 12, 1, 1, DateTimeKind.Utc);
+        public DateTime? DateTimeToTime { get; set; } = DateTime.Parse("2023-12-13T12:12:12.001001Z");
         [Field("datetimeoffset_to_time", FaunaType.Time)]
-        public DateTimeOffset? DateTimeOffsetToTime { get; set; } = new DateTimeOffset(new DateTime(2023, 12, 13, 12, 12, 12, 1, 1, DateTimeKind.Utc));
+        public DateTimeOffset? DateTimeOffsetToTime { get; set; } = new DateTimeOffset(DateTime.Parse("2023-12-13T12:12:12.001001Z"));
     }
 
 

--- a/Fauna.Test/Serialization/Serializer.Deserialize.Tests.cs
+++ b/Fauna.Test/Serialization/Serializer.Deserialize.Tests.cs
@@ -15,11 +15,11 @@ public partial class SerializerTests
         var tests = new Dictionary<string, object?>
         {
             {"\"hello\"", "hello"},
-            {"""{"@int":"42"}""", 42},
-            {"""{"@long":"42"}""", 42L},
-            {"""{"@double": "1.2"}""", 1.2d},
-            {"""{"@date": "2023-12-03"}""", new DateTime(2023, 12, 3)},
-            {"""{"@time": "2023-12-03T05:52:10.000001-09:00"}""", new DateTime(2023, 12, 3, 14, 52, 10, 0, 1, DateTimeKind.Utc).ToLocalTime()},
+            {@"{""@int"":""42""}", 42},
+            {@"{""@long"":""42""}", 42L},
+            {@"{""@double"": ""1.2""}", 1.2d},
+            {@"{""@date"": ""2023-12-03""}", new DateTime(2023, 12, 3)},
+            {@"{""@time"": ""2023-12-03T05:52:10.000001-09:00""}", new DateTime(2023, 12, 3, 14, 52, 10, 0, DateTimeKind.Utc).AddTicks(10).ToLocalTime()},
             {"true", true},
             {"false", false},
             {"null", null},
@@ -35,20 +35,20 @@ public partial class SerializerTests
     [Test]
     public void DeserializeObject()
     {
-        const string given = """
+        const string given = @"
                              {
-                                "aString": "foo",
-                                "anObject": { "baz": "luhrmann" },
-                                "anInt": { "@int": "2147483647" },
-                                "aLong":{ "@long": "9223372036854775807" },
-                                "aDouble":{ "@double": "3.14159" },
-                                "aDate":{ "@date": "2023-12-03" },
-                                "aTime":{ "@time": "2023-12-03T14:52:10.001001Z" },
-                                "true": true,
-                                "false": false,
-                                "null": null
+                                ""aString"": ""foo"",
+                                ""anObject"": { ""baz"": ""luhrmann"" },
+                                ""anInt"": { ""@int"": ""2147483647"" },
+                                ""aLong"":{ ""@long"": ""9223372036854775807"" },
+                                ""aDouble"":{ ""@double"": ""3.14159"" },
+                                ""aDate"":{ ""@date"": ""2023-12-03"" },
+                                ""aTime"":{ ""@time"": ""2023-12-03T14:52:10.001001Z"" },
+                                ""true"": true,
+                                ""false"": false,
+                                ""null"": null
                              }
-                             """;
+                             ";
 
         var inner = new Dictionary<string, object>
         {
@@ -63,7 +63,7 @@ public partial class SerializerTests
             { "aLong", 9223372036854775807 },
             { "aDouble", 3.14159d },
             { "aDate", new DateTime(2023, 12, 3) },
-            { "aTime", new DateTime(2023, 12, 3, 14, 52, 10, 1, 1, DateTimeKind.Utc).ToLocalTime() },
+            { "aTime", new DateTime(2023, 12, 3, 14, 52, 10, 1, DateTimeKind.Utc).AddTicks(10).ToLocalTime() },
             { "true", true },
             { "false", false },
             { "null", null }
@@ -76,16 +76,16 @@ public partial class SerializerTests
     [Test]
     public void DeserializeEscapedObject()
     {
-        const string given = """
+        const string given = @"
                              {
-                                "@object": {
-                                    "@int": "notanint",
-                                    "anInt": { "@int": "123" },
-                                    "@object": "notanobject",
-                                    "anEscapedObject": { "@object": { "@long": "notalong" } }
+                                ""@object"": {
+                                    ""@int"": ""notanint"",
+                                    ""anInt"": { ""@int"": ""123"" },
+                                    ""@object"": ""notanobject"",
+                                    ""anEscapedObject"": { ""@object"": { ""@long"": ""notalong"" } }
                                 }
                              }
-                             """;
+                             ";
 
         var inner = new Dictionary<string, object>
         {
@@ -110,13 +110,13 @@ public partial class SerializerTests
     public void DeserializeIntoPoco()
     {
 
-        const string given = """
+        const string given = @"
                              {
-                                "FirstName": "Baz2",
-                                "LastName": "Luhrmann2",
-                                "Age": { "@int": "612" }
+                                ""FirstName"": ""Baz2"",
+                                ""LastName"": ""Luhrmann2"",
+                                ""Age"": { ""@int"": ""612"" }
                              }
-                             """;
+                             ";
 
         var p = Serializer.Deserialize<Person>(given);
         Assert.AreEqual("Baz2", p.FirstName);
@@ -127,14 +127,14 @@ public partial class SerializerTests
     [Test]
     public void DeserializeIntoPocoWithAttributes()
     {
-        const string given = """
+        const string given = @"
                              {
-                                "first_name": "Baz2",
-                                "last_name": "Luhrmann2",
-                                "age": { "@int": "612" },
-                                "Ignored": "should be null"
+                                ""first_name"": ""Baz2"",
+                                ""last_name"": ""Luhrmann2"",
+                                ""age"": { ""@int"": ""612"" },
+                                ""Ignored"": ""should be null""
                              }
-                             """;
+                             ";
 
         var p = Serializer.Deserialize<PersonWithAttributes>(given);
         Assert.AreEqual("Baz2", p.FirstName);

--- a/Fauna.Test/Serialization/Serializer.Serialize.Tests.cs
+++ b/Fauna.Test/Serialization/Serializer.Serialize.Tests.cs
@@ -12,7 +12,7 @@ public partial class SerializerTests
     [Test]
     public void SerializeValues()
     {
-        var dt = new DateTime(2023, 12, 13, 12, 12, 12, 1, 1, DateTimeKind.Utc);
+        var dt = new DateTime(2023, 12, 13, 12, 12, 12, 1, DateTimeKind.Utc).AddTicks(10);
 
         var tests = new Dictionary<string, object?>
         {
@@ -20,16 +20,16 @@ public partial class SerializerTests
             {"true", true},
             {"false", false},
             {"null", null},
-            {"""{"@date":"2023-12-13"}""", new DateOnly(2023,12,13)},
-            {"""{"@double":"1.2"}""", 1.2d},
-            {"""{"@double":"3.14"}""", 3.14M},
-            {"""{"@int":"42"}""", 42},
-            {"""{"@long":"42"}""", 42L},
-            {"""{"@mod":"module"}""", new Module("module")},
-            {"""{"@time":"2023-12-13T12:12:12.0010010Z"}""", dt},
+            {@"{""@date"":""2023-12-13""}", new DateOnly(2023,12,13)},
+            {@"{""@double"":""1.2""}", 1.2d},
+            {@"{""@double"":""3.14""}", 3.14M},
+            {@"{""@int"":""42""}", 42},
+            {@"{""@long"":""42""}", 42L},
+            {@"{""@mod"":""module""}", new Module("module")},
+            {@"{""@time"":""2023-12-13T12:12:12.0010010Z""}", dt},
             // \u002 is the + character. This is expected because we do not
             // enable unsafe json serialization. Fauna wire protocol supports this.
-            {"""{"@time":"2023-12-14T12:12:12.0010010\u002B00:00"}""", new DateTimeOffset(dt.AddDays(1))},
+            {@"{""@time"":""2023-12-14T12:12:12.0010010\u002B00:00""}", new DateTimeOffset(dt.AddDays(1))},
         };
 
         foreach (var (expected, test) in tests)
@@ -52,7 +52,7 @@ public partial class SerializerTests
         };
 
         var actual = Serializer.Serialize(test);
-        Assert.AreEqual("""{"answer":{"@int":"42"},"foo":"bar","list":[],"obj":{}}""", actual);
+        Assert.AreEqual(@"{""answer"":{""@int"":""42""},""foo"":""bar"",""list"":[],""obj"":{}}", actual);
     }
 
     [Test]
@@ -60,16 +60,16 @@ public partial class SerializerTests
     {
         var tests = new Dictionary<Dictionary<string, object>, string>()
         {
-            { new() { { "@date", "not" } }, """{"@object":{"@date":"not"}}""" },
-            { new() { { "@doc", "not" } }, """{"@object":{"@doc":"not"}}""" },
-            { new() { { "@double", "not" } }, """{"@object":{"@double":"not"}}""" },
-            { new() { { "@int", "not" } }, """{"@object":{"@int":"not"}}""" },
-            { new() { { "@long", "not" } }, """{"@object":{"@long":"not"}}""" },
-            { new() { { "@mod", "not" } }, """{"@object":{"@mod":"not"}}""" },
-            { new() { { "@object", "not" } }, """{"@object":{"@object":"not"}}""" },
-            { new() { { "@ref", "not" } }, """{"@object":{"@ref":"not"}}""" },
-            { new() { { "@set", "not" } }, """{"@object":{"@set":"not"}}""" },
-            { new() { { "@time", "not" } }, """{"@object":{"@time":"not"}}""" }
+            { new() { { "@date", "not" } }, @"{""@object"":{""@date"":""not""}}" },
+            { new() { { "@doc", "not" } }, @"{""@object"":{""@doc"":""not""}}" },
+            { new() { { "@double", "not" } }, @"{""@object"":{""@double"":""not""}}" },
+            { new() { { "@int", "not" } }, @"{""@object"":{""@int"":""not""}}" },
+            { new() { { "@long", "not" } }, @"{""@object"":{""@long"":""not""}}" },
+            { new() { { "@mod", "not" } }, @"{""@object"":{""@mod"":""not""}}" },
+            { new() { { "@object", "not" } }, @"{""@object"":{""@object"":""not""}}" },
+            { new() { { "@ref", "not" } }, @"{""@object"":{""@ref"":""not""}}" },
+            { new() { { "@set", "not" } }, @"{""@object"":{""@set"":""not""}}" },
+            { new() { { "@time", "not" } }, @"{""@object"":{""@time"":""not""}}" }
         };
 
         foreach (var (test, expected) in tests)
@@ -91,7 +91,7 @@ public partial class SerializerTests
         };
 
         var actual = Serializer.Serialize(test);
-        Assert.AreEqual("""[{"@int":"42"},"foo bar",[],{}]""", actual);
+        Assert.AreEqual(@"[{""@int"":""42""},""foo bar"",[],{}]", actual);
     }
 
     [Test]
@@ -99,7 +99,7 @@ public partial class SerializerTests
     {
         var test = new Person();
         var actual = Serializer.Serialize(test);
-        Assert.AreEqual("""{"FirstName":"Baz","LastName":"Luhrmann","Age":{"@int":"61"}}""", actual);
+        Assert.AreEqual(@"{""FirstName"":""Baz"",""LastName"":""Luhrmann"",""Age"":{""@int"":""61""}}", actual);
     }
 
     [Test]
@@ -107,7 +107,7 @@ public partial class SerializerTests
     {
         var test = new PersonWithAttributes();
         var actual = Serializer.Serialize(test);
-        Assert.AreEqual("""{"first_name":"Baz","last_name":"Luhrmann","age":{"@long":"61"}}""", actual);
+        Assert.AreEqual(@"{""first_name"":""Baz"",""last_name"":""Luhrmann"",""age"":{""@long"":""61""}}", actual);
     }
 
     [Test]
@@ -115,16 +115,16 @@ public partial class SerializerTests
     {
         var tests = new Dictionary<object, string>()
         {
-            { new PersonWithDateConflict(), """{"@object":{"@date":"not"}}""" },
-            { new PersonWithDocConflict(), """{"@object":{"@doc":"not"}}""" },
-            { new PersonWithDoubleConflict(), """{"@object":{"@double":"not"}}""" },
-            { new PersonWithIntConflict(), """{"@object":{"@int":"not"}}""" },
-            { new PersonWithLongConflict(), """{"@object":{"@long":"not"}}""" },
-            { new PersonWithModConflict(), """{"@object":{"@mod":"not"}}""" },
-            { new PersonWithObjectConflict(), """{"@object":{"@object":"not"}}""" },
-            { new PersonWithRefConflict(), """{"@object":{"@ref":"not"}}""" },
-            { new PersonWithSetConflict(), """{"@object":{"@set":"not"}}""" },
-            { new PersonWithTimeConflict(), """{"@object":{"@time":"not"}}""" }
+            { new PersonWithDateConflict(), @"{""@object"":{""@date"":""not""}}" },
+            { new PersonWithDocConflict(), @"{""@object"":{""@doc"":""not""}}" },
+            { new PersonWithDoubleConflict(), @"{""@object"":{""@double"":""not""}}" },
+            { new PersonWithIntConflict(), @"{""@object"":{""@int"":""not""}}" },
+            { new PersonWithLongConflict(), @"{""@object"":{""@long"":""not""}}" },
+            { new PersonWithModConflict(), @"{""@object"":{""@mod"":""not""}}" },
+            { new PersonWithObjectConflict(), @"{""@object"":{""@object"":""not""}}" },
+            { new PersonWithRefConflict(), @"{""@object"":{""@ref"":""not""}}" },
+            { new PersonWithSetConflict(), @"{""@object"":{""@set"":""not""}}" },
+            { new PersonWithTimeConflict(), @"{""@object"":{""@time"":""not""}}" }
         };
 
         foreach (var (test, expected) in tests)
@@ -138,29 +138,29 @@ public partial class SerializerTests
     public void SerializeClassWithTypeConversions()
     {
         var test = new PersonWithTypeOverrides();
-        var expectedWithWhitespace = """
+        var expectedWithWhitespace = @"
                        {
-                           "short_to_long": {"@long": "1"},
-                           "int_to_long": {"@long": "2"},
-                           "long_to_long": {"@long": "3"},
-                           "short_to_int": {"@int": "4"},
-                           "int_to_int": {"@int": "5"},
-                           "short_to_double": {"@double": "6"},
-                           "int_to_double": {"@double": "7"},
-                           "long_to_double": {"@double": "8"},
-                           "decimal_to_double": {"@double": "9.2"},
-                           "double_to_double": {"@double": "10.1"},
-                           "true_to_true": true,
-                           "false_to_false": false,
-                           "class_to_string": "TheThing",
-                           "string_to_string": "aString",
-                           "datetime_to_date": {"@date": "2023-12-13"},
-                           "dateonly_to_date": {"@date": "2023-12-13"},
-                           "datetimeoffset_to_date": {"@date": "2023-12-13"},
-                           "datetime_to_time": {"@time":"2023-12-13T12:12:12.0010010Z"},
-                           "datetimeoffset_to_time": {"@time":"2023-12-13T12:12:12.0010010\u002B00:00"}
+                           ""short_to_long"": {""@long"": ""1""},
+                           ""int_to_long"": {""@long"": ""2""},
+                           ""long_to_long"": {""@long"": ""3""},
+                           ""short_to_int"": {""@int"": ""4""},
+                           ""int_to_int"": {""@int"": ""5""},
+                           ""short_to_double"": {""@double"": ""6""},
+                           ""int_to_double"": {""@double"": ""7""},
+                           ""long_to_double"": {""@double"": ""8""},
+                           ""decimal_to_double"": {""@double"": ""9.2""},
+                           ""double_to_double"": {""@double"": ""10.1""},
+                           ""true_to_true"": true,
+                           ""false_to_false"": false,
+                           ""class_to_string"": ""TheThing"",
+                           ""string_to_string"": ""aString"",
+                           ""datetime_to_date"": {""@date"": ""2023-12-13""},
+                           ""dateonly_to_date"": {""@date"": ""2023-12-13""},
+                           ""datetimeoffset_to_date"": {""@date"": ""2023-12-13""},
+                           ""datetime_to_time"": {""@time"":""2023-12-13T12:12:12.0010010Z""},
+                           ""datetimeoffset_to_time"": {""@time"":""2023-12-13T12:12:12.0010010\u002B00:00""}
                        }
-                       """;
+                       ";
         var expected = Regex.Replace(expectedWithWhitespace, @"\s", string.Empty);
         var actual = Serializer.Serialize(test);
         Assert.AreEqual(expected, actual);

--- a/Fauna.Test/Serialization/Utf8FaunaReader.Tests.cs
+++ b/Fauna.Test/Serialization/Utf8FaunaReader.Tests.cs
@@ -113,7 +113,7 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadInt()
     {
-        const string s = """{"@int": "123"}""";
+        const string s = @"{""@int"": ""123""}";
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>()
         {
@@ -126,7 +126,7 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadLong()
     {
-        const string s = """{"@long": "123"}""";
+        const string s = @"{""@long"": ""123""}";
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>()
         {
@@ -139,7 +139,7 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadDouble()
     {
-        const string s = """{"@double": "1.2"}""";
+        const string s = @"{""@double"": ""1.2""}";
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>()
         {
@@ -152,7 +152,7 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadDoubleAsDecimal()
     {
-        const string s = """{"@double": "1.2"}""";
+        const string s = @"{""@double"": ""1.2""}";
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>()
         {
@@ -165,7 +165,7 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadDate()
     {
-        const string s = """{"@date": "2023-12-03"}""";
+        const string s = @"{""@date"": ""2023-12-03""}";
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>()
         {
@@ -178,11 +178,11 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadTimePacific()
     {
-        const string s = """{"@time": "2023-12-03T05:52:10.000001-09:00"}""";
+        const string s = @"{""@time"": ""2023-12-03T05:52:10.000001-09:00""}";
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>()
         {
-            new(TokenType.Time, new DateTime(2023, 12, 3, 14, 52, 10, 0, 1, DateTimeKind.Utc).ToLocalTime())
+            new(TokenType.Time, new DateTime(2023, 12, 3, 14, 52, 10, 0, DateTimeKind.Utc).AddTicks(10).ToLocalTime())
         };
 
         AssertReader(reader, expectedTokens);
@@ -191,11 +191,11 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadTimeUtc()
     {
-        const string s = """{"@time": "2023-12-03T14:52:10.000001Z"}""";
+        const string s = @"{""@time"": ""2023-12-03T14:52:10.000001Z""}";
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>()
         {
-            new(TokenType.Time, new DateTime(2023, 12, 3, 14, 52, 10, 0, 1, DateTimeKind.Utc).ToLocalTime())
+            new(TokenType.Time, new DateTime(2023, 12, 3, 14, 52, 10, 0, DateTimeKind.Utc).AddTicks(10).ToLocalTime())
         };
 
         AssertReader(reader, expectedTokens);
@@ -204,7 +204,7 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadModule()
     {
-        const string s = """{"@mod": "MyCollection"}""";
+        const string s = @"{""@mod"": ""MyCollection""}";
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>()
         {
@@ -233,16 +233,16 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadEscapedObject()
     {
-        const string s = """
+        const string s = @"
                          {
-                            "@object": {
-                                "@int": "notanint",
-                                "anInt": { "@int": "123" },
-                                "@object": "notanobject",
-                                "anEscapedObject": { "@object": { "@long": "notalong" } }
+                            ""@object"": {
+                                ""@int"": ""notanint"",
+                                ""anInt"": { ""@int"": ""123"" },
+                                ""@object"": ""notanobject"",
+                                ""anEscapedObject"": { ""@object"": { ""@long"": ""notalong"" } }
                             }
                          }
-                         """;
+                         ";
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>
         {
@@ -267,16 +267,16 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadDocumentTokens()
     {
-        const string s = """
+        const string s = @"
                          {
-                            "@doc": {
-                                "id": "123",
-                                "coll": { "@mod": "Coll" },
-                                "ts": { "@time": "2023-12-03T16:07:23.111012Z" },
-                                "data": { "foo": "bar" }
+                            ""@doc"": {
+                                ""id"": ""123"",
+                                ""coll"": { ""@mod"": ""Coll"" },
+                                ""ts"": { ""@time"": ""2023-12-03T16:07:23.111012Z"" },
+                                ""data"": { ""foo"": ""bar"" }
                             }
                          }
-                         """;
+                         ";
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>
         {
@@ -286,7 +286,7 @@ public class Utf8FaunaReaderTests
             new(TokenType.FieldName, "coll"),
             new(TokenType.Module, new Module("Coll")),
             new(TokenType.FieldName, "ts"),
-            new(TokenType.Time, new DateTime(2023, 12, 03, 16, 07, 23, 111, 12, DateTimeKind.Utc).ToLocalTime()),
+            new(TokenType.Time, new DateTime(2023, 12, 03, 16, 07, 23, 111, DateTimeKind.Utc).AddTicks(120).ToLocalTime()),
             new(TokenType.FieldName, "data"),
             new(TokenType.StartObject, null),
             new(TokenType.FieldName, "foo"),
@@ -301,14 +301,14 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadSet()
     {
-        const string s = """
+        const string s = @"
                          {
-                            "@set": {
-                                "data": [{"@int": "99"}],
-                                "after": "afterme"
+                            ""@set"": {
+                                ""data"": [{""@int"": ""99""}],
+                                ""after"": ""afterme""
                             }
                          }
-                         """;
+                         ";
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>
         {
@@ -328,7 +328,7 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadRef()
     {
-        const string s = """{"@ref": {"id": "123", "coll": {"@mod": "Col"}}}""";
+        const string s = @"{""@ref"": {""id"": ""123"", ""coll"": {""@mod"": ""Col""}}}";
 
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>
@@ -347,23 +347,23 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadObjectTokens()
     {
-        const string s = """
+        const string s = @"
                          {
-                            "aString": "foo",
-                            "anObject": { "baz": "luhrmann" },
-                            "anInt": { "@int": "2147483647" },
-                            "aLong":{ "@long": "9223372036854775807" },
-                            "aDouble":{ "@double": "3.14159" },
-                            "aDecimal":{ "@double": "0.1" },
-                            "aDate":{ "@date": "2023-12-03" },
-                            "aTime":{ "@time": "2023-12-03T14:52:10.001001Z" },
-                            "anEscapedObject": { "@object": { "@int": "escaped" } },
-                            "anArray": [],
-                            "true": true,
-                            "false": false,
-                            "null": null
+                            ""aString"": ""foo"",
+                            ""anObject"": { ""baz"": ""luhrmann"" },
+                            ""anInt"": { ""@int"": ""2147483647"" },
+                            ""aLong"":{ ""@long"": ""9223372036854775807"" },
+                            ""aDouble"":{ ""@double"": ""3.14159"" },
+                            ""aDecimal"":{ ""@double"": ""0.1"" },
+                            ""aDate"":{ ""@date"": ""2023-12-03"" },
+                            ""aTime"":{ ""@time"": ""2023-12-03T14:52:10.001001Z"" },
+                            ""anEscapedObject"": { ""@object"": { ""@int"": ""escaped"" } },
+                            ""anArray"": [],
+                            ""true"": true,
+                            ""false"": false,
+                            ""null"": null
                          }
-                         """;
+                         ";
 
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>
@@ -395,7 +395,7 @@ public class Utf8FaunaReaderTests
             new(TokenType.Date, new DateTime(2023, 12, 3)),
 
             new(TokenType.FieldName, "aTime"),
-            new(TokenType.Time, new DateTime(2023, 12, 3, 14, 52, 10, 1, 1, DateTimeKind.Utc).ToLocalTime()),
+            new(TokenType.Time, new DateTime(2023, 12, 3, 14, 52, 10, 1, DateTimeKind.Utc).AddTicks(10).ToLocalTime()),
 
             new(TokenType.FieldName, "anEscapedObject"),
             new(TokenType.StartObject, null),
@@ -425,23 +425,23 @@ public class Utf8FaunaReaderTests
     [Test]
     public void ReadArray()
     {
-        const string s = """
+        const string s = @"
                          [
-                            "foo",
-                            { "baz": "luhrmann" },
-                            { "@int": "2147483647" },
-                            { "@long": "9223372036854775807" },
-                            { "@double": "3.14159" },
-                            { "@double": "0.1" },
-                            { "@date": "2023-12-03" },
-                            { "@time": "2023-12-03T14:52:10.001001Z" },
-                            { "@object": { "@int": "escaped" } },
+                            ""foo"",
+                            { ""baz"": ""luhrmann"" },
+                            { ""@int"": ""2147483647"" },
+                            { ""@long"": ""9223372036854775807"" },
+                            { ""@double"": ""3.14159"" },
+                            { ""@double"": ""0.1"" },
+                            { ""@date"": ""2023-12-03"" },
+                            { ""@time"": ""2023-12-03T14:52:10.001001Z"" },
+                            { ""@object"": { ""@int"": ""escaped"" } },
                             [],
                             true,
                             false,
                             null
                          ]
-                         """;
+                         ";
 
         var reader = new Utf8FaunaReader(s);
 
@@ -466,7 +466,7 @@ public class Utf8FaunaReaderTests
 
             new(TokenType.Date, new DateTime(2023, 12, 3)),
 
-            new(TokenType.Time, new DateTime(2023, 12, 3, 14, 52, 10, 1, 1, DateTimeKind.Utc).ToLocalTime()),
+            new(TokenType.Time, new DateTime(2023, 12, 3, 14, 52, 10, 1, DateTimeKind.Utc).AddTicks(10).ToLocalTime()),
 
             new(TokenType.StartObject, null),
             new(TokenType.FieldName, "@int"),
@@ -507,12 +507,12 @@ public class Utf8FaunaReaderTests
     {
         var tests = new List<string>()
         {
-            """{"k1": {}, "k2": {}}""",
-            """["k1",[],{}]""",
-            """{"@ref": {}}""",
-            """{"@doc": {}}""",
-            """{"@set": {}}""",
-            """{"@object":{}}"""
+            @"{""k1"": {}, ""k2"": {}}",
+            @"[""k1"",[],{}]",
+            @"{""@ref"": {}}",
+            @"{""@doc"": {}}",
+            @"{""@set"": {}}",
+            @"{""@object"":{}}"
         };
 
         foreach (var test in tests)
@@ -527,7 +527,7 @@ public class Utf8FaunaReaderTests
     [Test]
     public void SkipNestedEscapedObject()
     {
-        const string test = """{"@object":{"inner":{"@object":{"foo": "bar"}},"k2":{}}}""";
+        const string test = @"{""@object"":{""inner"":{""@object"":{""foo"": ""bar""}},""k2"":{}}}";
         var reader = new Utf8FaunaReader(test);
         reader.Read(); // {"@object":{
         Assert.AreEqual(TokenType.StartObject, reader.CurrentTokenType);
@@ -545,7 +545,7 @@ public class Utf8FaunaReaderTests
     [Test]
     public void SkipNestedObject()
     {
-        const string test = """{"k":{"inner":{}},"k2":{}}""";
+        const string test = @"{""k"":{""inner"":{}},""k2"":{}}";
         var reader = new Utf8FaunaReader(test);
         reader.Read(); // {
         Assert.AreEqual(TokenType.StartObject, reader.CurrentTokenType);
@@ -563,7 +563,7 @@ public class Utf8FaunaReaderTests
     [Test]
     public void SkipNestedArrays()
     {
-        const string test = """{"k":["1","2"],"k2":{}}""";
+        const string test = @"{""k"":[""1"",""2""],""k2"":{}}";
         var reader = new Utf8FaunaReader(test);
         reader.Read(); // {
         Assert.AreEqual(TokenType.StartObject, reader.CurrentTokenType);

--- a/Fauna.Test/Serialization/Utf8FaunaWriter.Tests.cs
+++ b/Fauna.Test/Serialization/Utf8FaunaWriter.Tests.cs
@@ -8,7 +8,6 @@ namespace Fauna.Test.Serialization;
 [TestFixture]
 public class Utf8FaunaWriterTests
 {
-
     private Utf8FaunaWriter _writer;
     private MemoryStream _stream;
 
@@ -36,21 +35,21 @@ public class Utf8FaunaWriterTests
     public void WriteIntValue()
     {
         _writer.WriteIntValue(42);
-        AssertWriter("""{"@int":"42"}""");
+        AssertWriter(@"{""@int"":""42""}");
     }
 
     [Test]
     public void WriteLongValue()
     {
         _writer.WriteLongValue(42L);
-        AssertWriter("""{"@long":"42"}""");
+        AssertWriter(@"{""@long"":""42""}");
     }
 
     [Test]
     public void WriteDoubleValue()
     {
         _writer.WriteDoubleValue(1.2d);
-        AssertWriter("""{"@double":"1.2"}""");
+        AssertWriter(@"{""@double"":""1.2""}");
     }
 
     [Test]
@@ -78,23 +77,23 @@ public class Utf8FaunaWriterTests
     public void WriteModuleValue()
     {
         _writer.WriteModuleValue(new Module("Authors"));
-        AssertWriter("""{"@mod":"Authors"}""");
+        AssertWriter(@"{""@mod"":""Authors""}");
     }
 
     [Test]
     public void WriteDate()
     {
-        var d = new DateTime(2023, 1, 1, 14, 04, 30, 1, 1, DateTimeKind.Utc);
+        var d = new DateTime(2023, 1, 1, 14, 04, 30, 1, DateTimeKind.Utc).AddTicks(10);
         _writer.WriteDateValue(d);
-        AssertWriter("""{"@date":"2023-01-01"}""");
+        AssertWriter(@"{""@date"":""2023-01-01""}");
     }
 
     [Test]
     public void WriteTime()
     {
-        var d = new DateTime(2023, 1, 1, 14, 04, 30, 1, 1, DateTimeKind.Utc);
+        var d = new DateTime(2023, 1, 1, 14, 04, 30, 1, DateTimeKind.Utc).AddTicks(10);
         _writer.WriteTimeValue(d);
-        AssertWriter("""{"@time":"2023-01-01T14:04:30.0010010Z"}""");
+        AssertWriter(@"{""@time"":""2023-01-01T14:04:30.0010010Z""}");
     }
 
     [Test]
@@ -109,7 +108,7 @@ public class Utf8FaunaWriterTests
         _writer.WriteBoolean("false", false);
         _writer.WriteString("foo", "bar");
         _writer.WriteDate("aDate", new DateTime(2023, 12, 4));
-        _writer.WriteTime("aTime", new DateTime(2023, 12, 4, 0, 0, 0, 0, 0, DateTimeKind.Utc));
+        _writer.WriteTime("aTime", new DateTime(2023, 12, 4, 0, 0, 0, 0, DateTimeKind.Utc));
         _writer.WriteNull("aNull");
         _writer.WriteFieldName("anArray");
         _writer.WriteStartArray();
@@ -118,7 +117,7 @@ public class Utf8FaunaWriterTests
         _writer.WriteStartObject();
         _writer.WriteEndObject();
         _writer.WriteEndObject();
-        AssertWriter("""{"anInt":{"@int":"42"},"aLong":{"@long":"42"},"aDouble":{"@double":"1.2"},"aDecimal":{"@double":"3.14"},"true":true,"false":false,"foo":"bar","aDate":{"@date":"2023-12-04"},"aTime":{"@time":"2023-12-04T00:00:00.0000000Z"},"aNull":null,"anArray":[],"anObject":{}}""");
+        AssertWriter(@"{""anInt"":{""@int"":""42""},""aLong"":{""@long"":""42""},""aDouble"":{""@double"":""1.2""},""aDecimal"":{""@double"":""3.14""},""true"":true,""false"":false,""foo"":""bar"",""aDate"":{""@date"":""2023-12-04""},""aTime"":{""@time"":""2023-12-04T00:00:00.0000000Z""},""aNull"":null,""anArray"":[],""anObject"":{}}");
     }
 
     [Test]
@@ -133,14 +132,14 @@ public class Utf8FaunaWriterTests
         _writer.WriteBooleanValue(false);
         _writer.WriteStringValue("bar");
         _writer.WriteDateValue(new DateTime(2023, 12, 4));
-        _writer.WriteTimeValue(new DateTime(2023, 12, 4, 0, 0, 0, 0, 0, DateTimeKind.Utc));
+        _writer.WriteTimeValue(new DateTime(2023, 12, 4, 0, 0, 0, 0, DateTimeKind.Utc));
         _writer.WriteNullValue();
         _writer.WriteStartArray();
         _writer.WriteEndArray();
         _writer.WriteStartObject();
         _writer.WriteEndObject();
         _writer.WriteEndArray();
-        AssertWriter("""[{"@int":"42"},{"@long":"42"},{"@double":"1.2"},{"@double":"3.14"},true,false,"bar",{"@date":"2023-12-04"},{"@time":"2023-12-04T00:00:00.0000000Z"},null,[],{}]""");
+        AssertWriter(@"[{""@int"":""42""},{""@long"":""42""},{""@double"":""1.2""},{""@double"":""3.14""},true,false,""bar"",{""@date"":""2023-12-04""},{""@time"":""2023-12-04T00:00:00.0000000Z""},null,[],{}]");
     }
 
     [Test]
@@ -148,7 +147,7 @@ public class Utf8FaunaWriterTests
     {
         _writer.WriteStartEscapedObject();
         _writer.WriteEndEscapedObject();
-        AssertWriter("""{"@object":{}}""");
+        AssertWriter(@"{""@object"":{}}");
     }
 
     [Test]
@@ -158,6 +157,6 @@ public class Utf8FaunaWriterTests
         _writer.WriteString("id", "123");
         _writer.WriteModule("coll", new Module("Authors"));
         _writer.WriteEndRef();
-        AssertWriter("""{"@ref":{"id":"123","coll":{"@mod":"Authors"}}}""");
+        AssertWriter(@"{""@ref"":{""id"":""123"",""coll"":{""@mod"":""Authors""}}}");
     }
 }


### PR DESCRIPTION
- `Fauna.Test` now targets net6.0 and net8.0; added net6.0 to the GHA test matrix
  - If you don't have .NET 6.0 installed (I don't), you can run `dotnet test -f net8.0` from the command line to run tests locally and not have it yell about .NET 6.0
- Had to update string literal handling due to C# language downgrade
- Updated `DateTime` constructors to include `AddTicks(micros * 10)`; tests are passing