### PR TITLE
Fix query serialization

### DIFF
--- a/Fauna.Test/QueryExpr.Tests.cs
+++ b/Fauna.Test/QueryExpr.Tests.cs
@@ -99,7 +99,7 @@ public class QueryExprTests
                     ""fql"": [
                         ""let product = Product.firstWhere(.backorderLimit == "",
                         { ""value"": { ""@int"": ""15""} },
-                        "" && .backordered == "",
+                        "" \u0026\u0026 .backordered == "",
                         { ""value"": false },
                         "")!; product.quantity;""
                     ]

--- a/Fauna.Test/QueryLiteral.Tests.cs
+++ b/Fauna.Test/QueryLiteral.Tests.cs
@@ -77,4 +77,15 @@ public class QueryLiteralTests
         var actual = queryLiteral.Serialize();
         Assert.AreEqual(expected, actual);
     }
+
+
+    [Test]
+    public void Serialize_CorrectlyEncodesNewLineCharacters()
+    {
+        var queryLiteral = new QueryLiteral(@"test
+value");
+        var expected = "\"test\\nvalue\"";
+        var actual = queryLiteral.Serialize();
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/Fauna/Client/Client.cs
+++ b/Fauna/Client/Client.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using Fauna.Constants;
+using Fauna.Serialization;
 
 namespace Fauna;
 
@@ -54,10 +55,12 @@ public class Client
 
     private static void Serialize(Stream stream, Query query)
     {
-        stream.Write(Encoding.UTF8.GetBytes("{\"query\":"));
-        query.Serialize(stream);
-        stream.Write(Encoding.UTF8.GetBytes("}"));
-        stream.Flush();
+        using var writer = new Utf8FaunaWriter(stream);
+        writer.WriteStartObject();
+        writer.WriteFieldName("query");
+        query.Serialize(writer);
+        writer.WriteEndObject();
+        writer.Flush();
     }
 
     private Dictionary<string, string> GetRequestHeaders(QueryOptions? queryOptions)

--- a/Fauna/Query/IQueryFragment.cs
+++ b/Fauna/Query/IQueryFragment.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using Fauna.Serialization;
 
 namespace Fauna;
 
@@ -11,8 +12,7 @@ public interface IQueryFragment
     /// Serializes the query fragment into a string format.
     /// </summary>
     /// <returns>A string representation of the query fragment.</returns>
-    void Serialize(Stream stream);
-    // string Serialize();
+    void Serialize(Utf8FaunaWriter writer);
 }
 
 public static class IQueryFragmentExtensions
@@ -20,8 +20,9 @@ public static class IQueryFragmentExtensions
     public static string Serialize(this IQueryFragment fragment)
     {
         using var ms = new MemoryStream();
-        fragment.Serialize(ms);
-        ms.Flush();
+        using var fw = new Utf8FaunaWriter(ms);
+        fragment.Serialize(fw);
+        fw.Flush();
         return Encoding.UTF8.GetString(ms.ToArray());
     }
 }

--- a/Fauna/Query/Query.cs
+++ b/Fauna/Query/Query.cs
@@ -1,8 +1,10 @@
+using Fauna.Serialization;
+
 namespace Fauna;
 
 public abstract class Query : IEquatable<Query>, IQueryFragment
 {
-    public abstract void Serialize(Stream stream);
+    public abstract void Serialize(Utf8FaunaWriter writer);
 
     public abstract override int GetHashCode();
 

--- a/Fauna/Query/QueryArr.cs
+++ b/Fauna/Query/QueryArr.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.ObjectModel;
+using Fauna.Serialization;
 
 namespace Fauna;
 
@@ -21,7 +22,7 @@ internal sealed class QueryArr<T> : Query, IQueryFragment, IEnumerable<T>
 
     public T this[int index] => Unwrap[index];
 
-    public override void Serialize(Stream stream)
+    public override void Serialize(Utf8FaunaWriter writer)
     {
         throw new NotImplementedException();
     }

--- a/Fauna/Query/QueryExpr.cs
+++ b/Fauna/Query/QueryExpr.cs
@@ -21,20 +21,17 @@ public sealed class QueryExpr : Query, IQueryFragment
 
     public ReadOnlyCollection<IQueryFragment> Fragments => Unwrap;
 
-    public override void Serialize(Stream stream)
+    public override void Serialize(Utf8FaunaWriter writer)
     {
-        stream.Write(Encoding.UTF8.GetBytes("{\"fql\":["));
-        for (var i = 0; i < Unwrap.Count; i++)
+        writer.WriteStartObject();
+        writer.WriteFieldName("fql");
+        writer.WriteStartArray();
+        foreach (var t in Unwrap)
         {
-            var t = Unwrap[i];
-            t.Serialize(stream);
-            if (i < Unwrap.Count - 1)
-            {
-                stream.Write(Encoding.UTF8.GetBytes(","));
-            }
+            t.Serialize(writer);
         }
-
-        stream.Write(Encoding.UTF8.GetBytes("]}"));
+        writer.WriteEndArray();
+        writer.WriteEndObject();
     }
 
     public override bool Equals(Query? o) => IsEqual(o as QueryExpr);

--- a/Fauna/Query/QueryLiteral.cs
+++ b/Fauna/Query/QueryLiteral.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using System.Text.Json;
+using Fauna.Serialization;
 
 namespace Fauna;
 
@@ -22,9 +23,9 @@ public sealed class QueryLiteral : IQueryFragment
         return $"QueryLiteral({Unwrap})";
     }
 
-    public void Serialize(Stream stream)
+    public void Serialize(Utf8FaunaWriter writer)
     {
-        stream.Write(Encoding.UTF8.GetBytes($"\"{Unwrap}\""));
+        writer.WriteStringValue(Unwrap);
     }
 
     public override bool Equals(object? other)

--- a/Fauna/Query/QueryVal.cs
+++ b/Fauna/Query/QueryVal.cs
@@ -13,11 +13,12 @@ public sealed class QueryVal<T> : Query, IQueryFragment
 
     public T Unwrap { get; }
 
-    public override void Serialize(Stream stream)
+    public override void Serialize(Utf8FaunaWriter writer)
     {
-        stream.Write(Encoding.UTF8.GetBytes("{\"value\":"));
-        Serializer.Serialize(stream, Unwrap);
-        stream.Write(Encoding.UTF8.GetBytes("}"));
+        writer.WriteStartObject();
+        writer.WriteFieldName("value");
+        Serializer.Serialize(writer, Unwrap);
+        writer.WriteEndObject();
     }
 
     public override bool Equals(Query? o) => IsEqual(o as QueryVal<T>);

--- a/Fauna/Serialization/Serializer.Serialize.cs
+++ b/Fauna/Serialization/Serializer.Serialize.cs
@@ -15,22 +15,16 @@ public static partial class Serializer
     {
         using var stream = new MemoryStream();
         using var writer = new Utf8FaunaWriter(stream);
-
-        var context = new SerializationContext();
-        SerializeValueInternal(writer, obj, context);
+        Serialize(writer, obj);
         writer.Flush();
         return Encoding.UTF8.GetString(stream.ToArray());
     }
 
-    public static void Serialize(Stream stream, object? obj)
+    public static void Serialize(Utf8FaunaWriter writer, object? obj)
     {
-        using var writer = new Utf8FaunaWriter(stream);
-
         var context = new SerializationContext();
         SerializeValueInternal(writer, obj, context);
-        writer.Flush();
     }
-
 
     private static void SerializeValueInternal(Utf8FaunaWriter writer, object? obj, SerializationContext context, FaunaType? typeHint = null)
     {


### PR DESCRIPTION
By encoding the bytes directly, we weren't properly escaping line feeds (and prob other chars) inside query literals.

Pass a Utf8FaunaWriter all the way down and use it. This ensures the entire structure is valid JSON.