### PR TITLE
Added initial backoff retry impementation

### DIFF
--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -29,8 +29,7 @@ public class IntegrationTests
             LastName = "O'Keeffe",
             Age = 136
         };
-
-        var conn = new Connection(new Uri("http://localhost:8443"), TimeSpan.FromSeconds(5));
+        var conn = new Connection(new Uri("http://localhost:8443"), TimeSpan.FromSeconds(5), 3, TimeSpan.FromSeconds(10));
         var client = new Client(new ClientConfig("secret"), conn);
         var query = FQL($"{expected}");
         var result = await client.QueryAsync<Person>(query);

--- a/Fauna/Client/Client.cs
+++ b/Fauna/Client/Client.cs
@@ -19,7 +19,7 @@ public class Client
     }
 
     public Client(ClientConfig config) :
-        this(config, new Connection(config.Endpoint, config.ConnectionTimeout))
+        this(config, new Connection(config.Endpoint, config.ConnectionTimeout, config.MaxRetries, config.MaxBackoff))
     {
     }
 

--- a/Fauna/Client/ClientConfig.cs
+++ b/Fauna/Client/ClientConfig.cs
@@ -4,15 +4,42 @@
 /// ClientConfig is a configuration class used to set up and configure a connection to Fauna.
 /// It encapsulates various settings such as the endpoint URL, secret key, query timeout, and others.
 /// </summary>
-public class ClientConfig
+public record ClientConfig
 {
+    /// <summary>
+    /// The secret key used for authentication.
+    /// </summary>
     public string Secret { get; init; }
+
+    /// <summary>
+    /// The endpoint URL of the Fauna server.
+    /// </summary>
     public Uri Endpoint { get; init; } = Constants.Endpoints.Default;
-    public TimeSpan ConnectionTimeout { get; init; } = DefaultConnectionTimeout;
+
+    /// <summary>
+    /// The timeout for the connection.
+    /// </summary>
+    public TimeSpan ConnectionTimeout { get; init; } = new(60);
+
+    /// <summary>
+    /// The maximum number of retry attempts for a request in case of failures.
+    /// </summary>
+    public int MaxRetries { get; init; } = 3;
+
+    /// <summary>
+    /// The maximum duration to wait between retry attempts.
+    /// </summary>
+    public TimeSpan MaxBackoff { get; init; } = new(20);
+
+    /// <summary>
+    /// Default options for queries sent to Fauna.
+    /// </summary>
     public QueryOptions? DefaultQueryOptions { get; init; } = null;
 
-    private static readonly TimeSpan DefaultConnectionTimeout = TimeSpan.FromSeconds(60);
-
+    /// <summary>
+    /// Initializes a new instance of the ClientConfig record with the specified secret key.
+    /// </summary>
+    /// <param name="secret">The secret key used for authentication.</param>
     public ClientConfig(string secret)
     {
         Secret = secret;


### PR DESCRIPTION
Added initial implementation of retry mechanism for handling transient failures (specifically HTTP 429 responses):
- Converted `ClientConfig` from a class to a record to enhance immutability and predictability
- Added `MaxRetries` and `MaxBackoff` in `Connection` for configurable retry policies
- Implemented exponential backoff for HTTP 429 responses
- Updated `Client` class to use new retry settings