### PR TITLE
Remove inner exceptions where not needed

### DIFF
--- a/Fauna.Test/Exceptions/AbortException.Tests.cs
+++ b/Fauna.Test/Exceptions/AbortException.Tests.cs
@@ -24,14 +24,9 @@ public class AbortExceptionTests
         var expectedInnerException = new Exception("Inner exception");
 
         var actual1 = new AbortException(ctx, expectedQueryFailure, expectedMessage);
-        var actual2 = new AbortException(ctx, expectedQueryFailure, expectedMessage, expectedInnerException);
 
         Assert.AreEqual(expectedQueryFailure.ErrorInfo.Abort, actual1.QueryFailure.ErrorInfo.Abort);
         Assert.AreEqual(expectedMessage, actual1.Message);
-
-        Assert.AreEqual(expectedQueryFailure.ErrorInfo.Abort, actual2.QueryFailure.ErrorInfo.Abort);
-        Assert.AreEqual(expectedMessage, actual2.Message);
-        Assert.AreEqual(expectedInnerException, actual2.InnerException);
     }
 
     [Test]

--- a/Fauna.Test/Exceptions/AuthenticationException.Tests.cs
+++ b/Fauna.Test/Exceptions/AuthenticationException.Tests.cs
@@ -17,18 +17,5 @@ namespace Fauna.Test.Exceptions
             Assert.AreEqual(exception.QueryFailure, queryFailure);
             Assert.AreEqual(exception.Message, message);
         }
-
-        [Test]
-        public void CtorWithQueryFailureMessageAndInnerException_ShouldSetProperties()
-        {
-            var queryFailure = ExceptionTestHelper.CreateQueryFailure("unauthorized");
-            var message = "Authentication error";
-            var innerException = new Exception("Inner exception");
-            var exception = new AuthenticationException(queryFailure, message, innerException);
-
-            Assert.AreEqual(exception.QueryFailure, queryFailure);
-            Assert.AreEqual(exception.Message, message);
-            Assert.AreEqual(exception.InnerException, innerException);
-        }
     }
 }

--- a/Fauna.Test/Exceptions/AuthorizationException.Tests.cs
+++ b/Fauna.Test/Exceptions/AuthorizationException.Tests.cs
@@ -17,18 +17,5 @@ namespace Fauna.Test.Exceptions
             Assert.AreEqual(exception.QueryFailure, queryFailure);
             Assert.AreEqual(exception.Message, message);
         }
-
-        [Test]
-        public void CtorWithQueryFailureMessageAndInnerException_ShouldSetProperties()
-        {
-            var queryFailure = ExceptionTestHelper.CreateQueryFailure("forbidden");
-            var message = "Authorization error";
-            var innerException = new Exception("Inner exception");
-            var exception = new AuthorizationException(queryFailure, message, innerException);
-
-            Assert.AreEqual(exception.QueryFailure, queryFailure);
-            Assert.AreEqual(exception.Message, message);
-            Assert.AreEqual(exception.InnerException, innerException);
-        }
     }
 }

--- a/Fauna.Test/Exceptions/ContendedTransactionException.Tests.cs
+++ b/Fauna.Test/Exceptions/ContendedTransactionException.Tests.cs
@@ -18,18 +18,5 @@ namespace Fauna.Test.Exceptions
             Assert.AreEqual(exception.QueryFailure, queryFailure);
             Assert.AreEqual(exception.Message, message);
         }
-
-        [Test]
-        public void CtorWithQueryFailureMessageAndInnerException_ShouldSetProperties()
-        {
-            var queryFailure = ExceptionTestHelper.CreateQueryFailure("contended_transaction");
-            var message = "Transaction contention occurred";
-            var innerException = new Exception("Inner exception");
-            var exception = new ContendedTransactionException(queryFailure, message, innerException);
-
-            Assert.AreEqual(exception.QueryFailure, queryFailure);
-            Assert.AreEqual(exception.Message, message);
-            Assert.AreEqual(exception.InnerException, innerException);
-        }
     }
 }

--- a/Fauna.Test/Exceptions/InvalidRequestException.Tests.cs
+++ b/Fauna.Test/Exceptions/InvalidRequestException.Tests.cs
@@ -17,18 +17,5 @@ namespace Fauna.Test.Exceptions
             Assert.AreEqual(exception.QueryFailure, queryFailure);
             Assert.AreEqual(exception.Message, message);
         }
-
-        [Test]
-        public void CtorWithQueryFailureMessageAndInnerException_ShouldSetProperties()
-        {
-            var queryFailure = ExceptionTestHelper.CreateQueryFailure("invalid_request");
-            var message = "Invalid request error";
-            var innerException = new Exception("Inner exception");
-            var exception = new InvalidRequestException(queryFailure, message, innerException);
-
-            Assert.AreEqual(exception.QueryFailure, queryFailure);
-            Assert.AreEqual(exception.Message, message);
-            Assert.AreEqual(exception.InnerException, innerException);
-        }
     }
 }

--- a/Fauna.Test/Exceptions/QueryCheckException.Tests.cs
+++ b/Fauna.Test/Exceptions/QueryCheckException.Tests.cs
@@ -17,18 +17,5 @@ namespace Fauna.Test.Exceptions
             Assert.AreEqual(exception.QueryFailure, queryFailure);
             Assert.AreEqual(exception.Message, message);
         }
-
-        [Test]
-        public void CtorWithQueryFailureMessageAndInnerException_ShouldSetProperties()
-        {
-            var queryFailure = ExceptionTestHelper.CreateQueryFailure("invalid_query");
-            var message = "Query check error";
-            var innerException = new Exception("Inner exception");
-            var exception = new QueryCheckException(queryFailure, message, innerException);
-
-            Assert.AreEqual(exception.QueryFailure, queryFailure);
-            Assert.AreEqual(exception.Message, message);
-            Assert.AreEqual(exception.InnerException, innerException);
-        }
     }
 }

--- a/Fauna.Test/Exceptions/QueryRuntimeException.Tests.cs
+++ b/Fauna.Test/Exceptions/QueryRuntimeException.Tests.cs
@@ -17,18 +17,5 @@ namespace Fauna.Test.Exceptions
             Assert.AreEqual(exception.QueryFailure, queryFailure);
             Assert.AreEqual(exception.Message, message);
         }
-
-        [Test]
-        public void CtorWithQueryFailureMessageAndInnerException_ShouldSetProperties()
-        {
-            var queryFailure = ExceptionTestHelper.CreateQueryFailure("invalid_argument");
-            var message = "Query runtime error";
-            var innerException = new Exception("Inner exception");
-            var exception = new QueryRuntimeException(queryFailure, message, innerException);
-
-            Assert.AreEqual(exception.QueryFailure, queryFailure);
-            Assert.AreEqual(exception.Message, message);
-            Assert.AreEqual(exception.InnerException, innerException);
-        }
     }
 }

--- a/Fauna.Test/Exceptions/QueryTimeoutException.Tests.cs
+++ b/Fauna.Test/Exceptions/QueryTimeoutException.Tests.cs
@@ -17,18 +17,5 @@ namespace Fauna.Test.Exceptions
             Assert.AreEqual(exception.QueryFailure, queryFailure);
             Assert.AreEqual(exception.Message, message);
         }
-
-        [Test]
-        public void CtorWithQueryFailureMessageAndInnerException_ShouldSetProperties()
-        {
-            var queryFailure = ExceptionTestHelper.CreateQueryFailure("time_limit_exceeded");
-            var message = "Query timeout error";
-            var innerException = new Exception("Inner exception");
-            var exception = new QueryTimeoutException(queryFailure, message, innerException);
-
-            Assert.AreEqual(exception.QueryFailure, queryFailure);
-            Assert.AreEqual(exception.Message, message);
-            Assert.AreEqual(exception.InnerException, innerException);
-        }
     }
 }

--- a/Fauna.Test/Exceptions/ServiceException.Tests.cs
+++ b/Fauna.Test/Exceptions/ServiceException.Tests.cs
@@ -17,18 +17,5 @@ namespace Fauna.Test.Exceptions
             Assert.AreEqual(exception.QueryFailure, queryFailure);
             Assert.AreEqual(exception.Message, message);
         }
-
-        [Test]
-        public void CtorWithQueryFailureMessageAndInnerException_ShouldSetProperties()
-        {
-            var queryFailure = ExceptionTestHelper.CreateQueryFailure("internal_error");
-            var message = "Service error";
-            var innerException = new Exception("Inner exception");
-            var exception = new ServiceException(queryFailure, message, innerException);
-
-            Assert.AreEqual(exception.QueryFailure, queryFailure);
-            Assert.AreEqual(exception.Message, message);
-            Assert.AreEqual(exception.InnerException, innerException);
-        }
     }
 }

--- a/Fauna.Test/Exceptions/ThrottlingException.Tests.cs
+++ b/Fauna.Test/Exceptions/ThrottlingException.Tests.cs
@@ -17,18 +17,5 @@ namespace Fauna.Test.Exceptions
             Assert.AreEqual(exception.QueryFailure, queryFailure);
             Assert.AreEqual(exception.Message, message);
         }
-
-        [Test]
-        public void CtorWithQueryFailureMessageAndInnerException_ShouldSetProperties()
-        {
-            var queryFailure = ExceptionTestHelper.CreateQueryFailure("limit_exceeded");
-            var message = "Throttling error occurred";
-            var innerException = new Exception("Inner exception");
-            var exception = new ThrottlingException(queryFailure, message, innerException);
-
-            Assert.AreEqual(exception.QueryFailure, queryFailure);
-            Assert.AreEqual(exception.Message, message);
-            Assert.AreEqual(exception.InnerException, innerException);
-        }
     }
 }

--- a/Fauna.Test/Exceptions/WriteConstraintException.Tests.cs
+++ b/Fauna.Test/Exceptions/WriteConstraintException.Tests.cs
@@ -17,18 +17,5 @@ namespace Fauna.Test.Exceptions
             Assert.AreEqual(exception.QueryFailure, queryFailure);
             Assert.AreEqual(exception.Message, message);
         }
-
-        [Test]
-        public void CtorWithQueryFailureMessageAndInnerException_ShouldSetProperties()
-        {
-            var queryFailure = ExceptionTestHelper.CreateQueryFailure("write_constraint_error");
-            var message = "Write constraint error";
-            var innerException = new Exception("Inner exception");
-            var exception = new WriteConstraintException(queryFailure, message, innerException);
-
-            Assert.AreEqual(exception.QueryFailure, queryFailure);
-            Assert.AreEqual(exception.Message, message);
-            Assert.AreEqual(exception.InnerException, innerException);
-        }
     }
 }

--- a/Fauna/Exceptions/AuthenticationException.cs
+++ b/Fauna/Exceptions/AuthenticationException.cs
@@ -4,7 +4,4 @@ public class AuthenticationException : ServiceException
 {
     public AuthenticationException(QueryFailure queryFailure, string message)
         : base(queryFailure, message) { }
-
-    public AuthenticationException(QueryFailure queryFailure, string message, Exception innerException)
-        : base(queryFailure, message, innerException) { }
 }

--- a/Fauna/Exceptions/AuthorizationException.cs
+++ b/Fauna/Exceptions/AuthorizationException.cs
@@ -4,7 +4,4 @@ public class AuthorizationException : ServiceException
 {
     public AuthorizationException(QueryFailure queryFailure, string message)
         : base(queryFailure, message) { }
-
-    public AuthorizationException(QueryFailure queryFailure, string message, Exception innerException)
-        : base(queryFailure, message, innerException) { }
 }

--- a/Fauna/Exceptions/ContendedTransactionException.cs
+++ b/Fauna/Exceptions/ContendedTransactionException.cs
@@ -8,7 +8,4 @@ public class ContendedTransactionException : ServiceException, IRetryableExcepti
 {
     public ContendedTransactionException(QueryFailure queryFailure, string message)
         : base(queryFailure, message) { }
-
-    public ContendedTransactionException(QueryFailure queryFailure, string message, Exception innerException)
-        : base(queryFailure, message, innerException) { }
 }

--- a/Fauna/Exceptions/InvalidRequestException.cs
+++ b/Fauna/Exceptions/InvalidRequestException.cs
@@ -7,7 +7,4 @@ public class InvalidRequestException : ServiceException
 {
     public InvalidRequestException(QueryFailure queryFailure, string message)
         : base(queryFailure, message) { }
-
-    public InvalidRequestException(QueryFailure queryFailure, string message, Exception innerException)
-        : base(queryFailure, message, innerException) { }
 }

--- a/Fauna/Exceptions/QueryCheckException.cs
+++ b/Fauna/Exceptions/QueryCheckException.cs
@@ -4,7 +4,4 @@ public class QueryCheckException : ServiceException
 {
     public QueryCheckException(QueryFailure queryFailure, string message)
         : base(queryFailure, message) { }
-
-    public QueryCheckException(QueryFailure queryFailure, string message, Exception innerException)
-        : base(queryFailure, message, innerException) { }
 }

--- a/Fauna/Exceptions/QueryRuntimeException.cs
+++ b/Fauna/Exceptions/QueryRuntimeException.cs
@@ -7,7 +7,4 @@ public class QueryRuntimeException : ServiceException
 {
     public QueryRuntimeException(QueryFailure queryFailure, string message)
         : base(queryFailure, message) { }
-
-    public QueryRuntimeException(QueryFailure queryFailure, string message, Exception innerException)
-        : base(queryFailure, message, innerException) { }
 }

--- a/Fauna/Exceptions/QueryTimeoutException.cs
+++ b/Fauna/Exceptions/QueryTimeoutException.cs
@@ -4,7 +4,4 @@ public class QueryTimeoutException : ServiceException
 {
     public QueryTimeoutException(QueryFailure queryFailure, string message)
         : base(queryFailure, message) { }
-
-    public QueryTimeoutException(QueryFailure queryFailure, string message, Exception innerException)
-        : base(queryFailure, message, innerException) { }
 }

--- a/Fauna/Exceptions/ServiceException.cs
+++ b/Fauna/Exceptions/ServiceException.cs
@@ -18,13 +18,4 @@ public class ServiceException : FaunaException
     /// <param name="message">The error message that explains the reason for the exception.</param>
     public ServiceException(QueryFailure queryFailure, string message)
         : base(message) => QueryFailure = queryFailure;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ServiceException"/> class with a specified query failure details, error message, and a reference to the inner exception.
-    /// </summary>
-    /// <param name="queryFailure">The <see cref="QueryFailure"/> object containing details about the query failure.</param>
-    /// <param name="message">The error message that explains the reason for the exception.</param>
-    /// <param name="innerException">The exception that is the cause of the current exception, represented by an <see cref="Exception"/> object.</param>
-    public ServiceException(QueryFailure queryFailure, string message, Exception innerException)
-        : base(message, innerException) => QueryFailure = queryFailure;
 }

--- a/Fauna/Exceptions/ThrottlingException.cs
+++ b/Fauna/Exceptions/ThrottlingException.cs
@@ -8,7 +8,4 @@ public class ThrottlingException : ServiceException, IRetryableException
 {
     public ThrottlingException(QueryFailure queryFailure, string message)
         : base(queryFailure, message) { }
-
-    public ThrottlingException(QueryFailure queryFailure, string message, Exception innerException)
-        : base(queryFailure, message, innerException) { }
 }

--- a/Fauna/Exceptions/WriteConstraintException.cs
+++ b/Fauna/Exceptions/WriteConstraintException.cs
@@ -4,7 +4,4 @@ public class WriteConstraintException : QueryRuntimeException
 {
     public WriteConstraintException(QueryFailure queryFailure, string message)
         : base(queryFailure, message) { }
-
-    public WriteConstraintException(QueryFailure queryFailure, string message, Exception innerException)
-        : base(queryFailure, message, innerException) { }
 }


### PR DESCRIPTION
We don't always need to pass an inner exception, so remove support for it where not needed.