### PR TITLE
WIP - linq deserializers

### DIFF
--- a/Fauna/Serialization/LinqElementDeserializer.cs
+++ b/Fauna/Serialization/LinqElementDeserializer.cs
@@ -1,0 +1,55 @@
+namespace Fauna.Serialization;
+
+public class LinqProjectionDeserializer<T> : BaseDeserializer<T>
+{
+    private IDeserializer[] _fieldDeserializers;
+    private Delegate _mapper;
+
+    public LinqProjectionDeserializer(IDeserializer[] fields, Delegate mapper)
+    {
+        _fieldDeserializers = fields;
+        _mapper = mapper;
+    }
+
+    public override T Deserialize(SerializationContext context, ref Utf8FaunaReader reader)
+    {
+        if (reader.CurrentTokenType != TokenType.StartArray)
+            throw UnexpectedToken(reader.CurrentTokenType);
+
+        var fields = new object?[_fieldDeserializers.Length];
+
+        for (var i = 0; i < _fieldDeserializers.Length; i++)
+        {
+            if (!reader.Read()) throw new SerializationException("Unexpected end of stream");
+            if (reader.CurrentTokenType == TokenType.EndArray) throw UnexpectedToken(reader.CurrentTokenType);
+
+            fields[i] = _fieldDeserializers[i].Deserialize(context, ref reader);
+        }
+
+        if (!reader.Read()) throw new SerializationException("Unexpected end of stream");
+        if (reader.CurrentTokenType != TokenType.EndArray) throw UnexpectedToken(reader.CurrentTokenType);
+
+        return (T)_mapper.DynamicInvoke(fields)!;
+    }
+
+    private SerializationException UnexpectedToken(TokenType tokenType) =>
+        new SerializationException($"Unexpected token while deserializing LINQ element: {tokenType}");
+}
+
+public class LinqDocumentDeserializer<T> : BaseDeserializer<T>
+{
+    private IDeserializer _docDeserializer;
+    private Delegate _mapper;
+
+    public LinqDocumentDeserializer(IDeserializer doc, Delegate mapper)
+    {
+        _docDeserializer = doc;
+        _mapper = mapper;
+    }
+
+    public override T Deserialize(SerializationContext context, ref Utf8FaunaReader reader)
+    {
+        var doc = _docDeserializer.Deserialize(context, ref reader);
+        return (T)_mapper.DynamicInvoke(new[] { doc })!;
+    }
+}


### PR DESCRIPTION
This PR contains linq element deserializers. I need two variants:
- if the Select body only reads fields off each document, not letting it escape, we will map that to an array of specific field values, and the accompanying deserializer needs to deserialize each field and pass the resulting tuple to a mapping function to the return type of the Select lambda.
- if the Select body allows the document to escape, we deserialize to the document type and pass it to a mapping function.

Eventually the LINQ impl will wire up the deserializer for a page of elements with something like:

```
IDeserializer<Doc> docDeser = ...generated doc deserializer...;
Func<Doc, T> mapper = ...generated mapper...;
var linqDeser = new LinqDocumentDeserializer(docDeser, mapper);
var deser = new PageDeserializer<T>(linqDeser);
```

We can then store this deserializer alongside the other generated LINQ query apparatus, such as the FQL builder lambda.