### PR TITLE
minor: uncapitalize field names by default

### DIFF
--- a/Fauna.Test/Exceptions/AbortException.Tests.cs
+++ b/Fauna.Test/Exceptions/AbortException.Tests.cs
@@ -76,7 +76,7 @@ public class AbortExceptionTests
     public void GetDataT_WithPocoData_ReturnsDeserializedTypedObject()
     {
         var expected = new TestClass { Name = "John", Age = 105 };
-        var queryFailure = ExceptionTestHelper.CreateQueryFailure("abort", "Query aborted.", $"{{\"@object\":{{\"Name\":\"{expected.Name}\",\"Age\":{{\"@int\":\"{expected.Age}\"}}}}}}");
+        var queryFailure = ExceptionTestHelper.CreateQueryFailure("abort", "Query aborted.", $"{{\"@object\":{{\"name\":\"{expected.Name}\",\"age\":{{\"@int\":\"{expected.Age}\"}}}}}}");
         var exception = new AbortException(ctx, queryFailure, "Test message");
 
         var actual = exception.GetData<TestClass>();

--- a/Fauna.Test/Serialization/Deserializer.Tests.cs
+++ b/Fauna.Test/Serialization/Deserializer.Tests.cs
@@ -380,9 +380,9 @@ public class DeserializerTests
 
         const string given = @"
                              {
-                                ""FirstName"": ""Baz2"",
-                                ""LastName"": ""Luhrmann2"",
-                                ""Age"": { ""@int"": ""612"" }
+                                ""firstName"": ""Baz2"",
+                                ""lastName"": ""Luhrmann2"",
+                                ""age"": { ""@int"": ""612"" }
                              }
                              ";
 
@@ -400,7 +400,7 @@ public class DeserializerTests
                                 ""first_name"": ""Baz2"",
                                 ""last_name"": ""Luhrmann2"",
                                 ""age"": { ""@int"": ""612"" },
-                                ""Ignored"": ""should be null""
+                                ""ignored"": ""should be null""
                              }
                              ";
 

--- a/Fauna.Test/Serialization/Serializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializer.Tests.cs
@@ -116,7 +116,7 @@ public class SerializerTests
     {
         var test = new Person();
         var actual = Serialize(test);
-        Assert.AreEqual(@"{""FirstName"":""Baz"",""LastName"":""Luhrmann"",""Age"":{""@int"":""61""}}", actual);
+        Assert.AreEqual(@"{""firstName"":""Baz"",""lastName"":""Luhrmann"",""age"":{""@int"":""61""}}", actual);
     }
 
     [Test]
@@ -201,7 +201,7 @@ public class SerializerTests
     public void SerializeObjectWithFieldAttributeAndWithoutObjectAttribute()
     {
         var obj = new ClassWithFieldAttributeAndWithoutObjectAttribute();
-        var expected = "{\"FirstName\":\"Baz\"}";
+        var expected = "{\"firstName\":\"Baz\"}";
         var actual = Serialize(obj);
         Assert.AreEqual(expected, actual);
     }
@@ -219,7 +219,7 @@ public class SerializerTests
     public void SerializeAnonymousClassObject()
     {
         var obj = new { FirstName = "John", LastName = "Doe" };
-        var expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\"}";
+        var expected = "{\"firstName\":\"John\",\"lastName\":\"Doe\"}";
         var actual = Serialize(obj);
         Assert.AreEqual(expected, actual);
     }

--- a/Fauna/Mapping/FieldInfo.cs
+++ b/Fauna/Mapping/FieldInfo.cs
@@ -23,5 +23,11 @@ public sealed class FieldInfo
         IsNullable = nullInfo.WriteState is NullabilityState.Nullable;
     }
 
-    private static string CanonicalFieldName(PropertyInfo prop) => prop.Name;
+    // C# properties are capitalized whereas Fauna fields are not by convention.
+    private static string CanonicalFieldName(PropertyInfo prop) =>
+        prop.Name switch
+        {
+            var name when string.IsNullOrEmpty(name) || char.IsLower(name[0]) => name,
+            var name => string.Concat(name[0].ToString().ToLower(), name.AsSpan(1))
+        };
 }


### PR DESCRIPTION
Fauna field names are lowercase by convention, so translate by default.