### PR TITLE
Drop collection attribute

### DIFF
--- a/Fauna.Test/Linq/ContextValidation.Tests.cs
+++ b/Fauna.Test/Linq/ContextValidation.Tests.cs
@@ -8,13 +8,13 @@ namespace Fauna.Test.Linq;
 [TestFixture]
 public class ContextValidationTests
 {
-    [Collection]
+    [Object]
     class Foo
     {
         [Field] public string? Id { get; set; }
     }
 
-    [Collection]
+    [Object]
     class Bar
     {
         [Field] public string? Id { get; set; }

--- a/Fauna.Test/Serialization/TestClasses.cs
+++ b/Fauna.Test/Serialization/TestClasses.cs
@@ -9,27 +9,27 @@ class Person
     public int Age { get; set; } = 61;
 }
 
-[Collection]
+[Object]
 class ClassForDocument
 {
     [Field] public long Id { get; set; }
     [Field("user_field")] public string? UserField { get; set; }
 }
 
-[Collection]
+[Object]
 class ClassForDocumentWithIdString
 {
     [Field] public string? Id { get; set; }
     [Field("user_field")] public string? UserField { get; set; }
 }
 
-[Collection]
+[Object]
 class ClassForDocumentWithInvalidId
 {
     [Field] public bool Id { get; set; }
 }
 
-[Collection]
+[Object]
 class ClassForNamedDocument
 {
     [Field("name")] public string? Name { get; set; }

--- a/Fauna/Mapping/Attributes.cs
+++ b/Fauna/Mapping/Attributes.cs
@@ -15,23 +15,7 @@ public enum FaunaType
 }
 
 /// <summary>
-/// Attribute used to indicate that a class represents a Fauna collection.
-/// </summary>
-[AttributeUsage(AttributeTargets.Class)]
-public class CollectionAttribute : Attribute
-{
-    internal readonly string? Name;
-
-    public CollectionAttribute() { }
-
-    public CollectionAttribute(string name)
-    {
-        Name = name;
-    }
-}
-
-/// <summary>
-/// Attribute used to indicate that a class represents a Fauna object.
+/// Attribute used to indicate that a class represents a Fauna document or struct.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class)]
 public class ObjectAttribute : Attribute

--- a/Fauna/Mapping/MappingInfo.cs
+++ b/Fauna/Mapping/MappingInfo.cs
@@ -8,8 +8,6 @@ namespace Fauna.Mapping;
 public sealed class MappingInfo
 {
     public readonly Type Type;
-    public readonly string? Collection;
-    public readonly bool IsCollection;
     public readonly IReadOnlyList<FieldInfo> Fields;
     public readonly IReadOnlyDictionary<string, FieldInfo> FieldsByName;
 
@@ -21,13 +19,8 @@ public sealed class MappingInfo
         ctx.Add(ty, this);
         Type = ty;
 
-        var collAttr = ty.GetCustomAttribute<CollectionAttribute>();
         var objAttr = ty.GetCustomAttribute<ObjectAttribute>();
-        var hasAttributes = collAttr != null || objAttr != null;
-
-        Collection = collAttr?.Name;
-        IsCollection = Collection is not null;
-
+        var hasAttributes = objAttr != null;
         var fields = new List<FieldInfo>();
         var byName = new Dictionary<string, FieldInfo>();
 


### PR DESCRIPTION
Since collections will be attached to a data context, it's not necessary to annotate them. The remaining class attr is currently "Object" but we probably want to rename that one, I think.