### PR TITLE
Remove generic param from QueryVal

### DIFF
--- a/Fauna.Test/Query.Tests.cs
+++ b/Fauna.Test/Query.Tests.cs
@@ -15,9 +15,9 @@ public class QueryTests
 
         var expected = new QueryExpr(
             new QueryLiteral("Book.where(.title == "),
-            new QueryVal<string>("foo"),
+            new QueryVal("foo"),
             new QueryLiteral(" && .genre == "),
-            new QueryVal<string>("bar"),
+            new QueryVal("bar"),
             new QueryLiteral(")")
         );
 
@@ -36,9 +36,9 @@ public class QueryTests
         var expected = new QueryExpr(new QueryLiteral("Product.where(.quantity == "),
             new QueryExpr(
                 new QueryLiteral("let product = Product.firstWhere(.backorderLimit == "),
-                new QueryVal<int>(backorderLimit),
+                new QueryVal(backorderLimit),
                 new QueryLiteral(" && .backordered == "),
-                new QueryVal<bool>(isBackordered),
+                new QueryVal(isBackordered),
                 new QueryLiteral(")!; product.quantity;")
             ),
             new QueryLiteral(").order(.title) { name, description }")
@@ -52,7 +52,7 @@ public class QueryTests
     {
         var guidParam = Guid.NewGuid();
 
-        var expected = new QueryExpr(new QueryLiteral("let x = '"), new QueryVal<Guid>(guidParam), new QueryLiteral("';"));
+        var expected = new QueryExpr(new QueryLiteral("let x = '"), new QueryVal(guidParam), new QueryLiteral("';"));
 
         var actual = FQL($@"let x = '{guidParam}';");
 
@@ -69,7 +69,7 @@ public class QueryTests
             new[] { "item21", "item22" }
         };
 
-        var expected = new QueryExpr(new QueryLiteral("let x = "), new QueryVal<object[]>(arrayParam));
+        var expected = new QueryExpr(new QueryLiteral("let x = "), new QueryVal(arrayParam));
 
         var actual = FQL($@"let x = {arrayParam}");
 
@@ -86,7 +86,7 @@ public class QueryTests
             new[] { "item21", "item22" }
         };
 
-        var expected = new QueryExpr(new QueryLiteral("let x = "), new QueryVal<List<object>>(listParam));
+        var expected = new QueryExpr(new QueryLiteral("let x = "), new QueryVal(listParam));
 
         var actual = FQL($@"let x = {listParam}");
 
@@ -102,7 +102,7 @@ public class QueryTests
             { "key3", new[] { "item21", "item22" } }
         };
 
-        var expected = new QueryExpr(new QueryLiteral("let x = "), new QueryVal<IDictionary<string, object>>(dictionaryParam));
+        var expected = new QueryExpr(new QueryLiteral("let x = "), new QueryVal(dictionaryParam));
 
 
         var actual = FQL($@"let x = {dictionaryParam}");

--- a/Fauna.Test/QueryExpr.Tests.cs
+++ b/Fauna.Test/QueryExpr.Tests.cs
@@ -12,7 +12,7 @@ public class QueryExprTests
     {
         var fragment1 = new QueryLiteral("fragment1");
         var fragment2 = new QueryExpr(new QueryLiteral("fragment2"));
-        var fragment3 = new QueryVal<int>(123);
+        var fragment3 = new QueryVal(123);
         var expected = new List<IQueryFragment> { fragment1, fragment2, fragment3 };
 
         var actual1 = new QueryExpr(expected);
@@ -29,7 +29,7 @@ public class QueryExprTests
         {
         new QueryLiteral("fragment1"),
         new QueryExpr(new QueryLiteral("fragment2")),
-        new QueryVal<int>(123)
+        new QueryVal(123)
         };
 
         Assert.DoesNotThrow(() => new QueryExpr(validFragments));
@@ -126,7 +126,7 @@ public class QueryExprTests
     {
         var mixedExpr = new QueryExpr(
             new QueryLiteral("literal"),
-            new QueryVal<int>(123),
+            new QueryVal(123),
             new QueryExpr(new QueryLiteral("nested"))
         );
         var query = mixedExpr.Serialize();
@@ -145,8 +145,8 @@ public class QueryExprTests
             return random.Next(3) switch
             {
                 0 => new QueryLiteral($"literal{i}"),
-                1 => new QueryVal<string>($"value{i}"),
-                2 => new QueryExpr(new QueryLiteral($"nestedLiteral{i}"), new QueryVal<int>(i)),
+                1 => new QueryVal($"value{i}"),
+                2 => new QueryExpr(new QueryLiteral($"nestedLiteral{i}"), new QueryVal(i)),
                 _ => throw new InvalidOperationException()
             };
         }

--- a/Fauna.Test/QueryVal.Tests.cs
+++ b/Fauna.Test/QueryVal.Tests.cs
@@ -15,7 +15,7 @@ public class QueryValTests
     public void Ctor_WrapsFloatCorrectly()
     {
         float expected = float.MaxValue;
-        var actual = new QueryVal<float>(expected);
+        var actual = new QueryVal(expected);
         Assert.AreEqual(expected, actual.Unwrap);
         Assert.IsInstanceOf<float>(actual.Unwrap);
     }
@@ -24,7 +24,7 @@ public class QueryValTests
     public void Ctor_WrapsIntCorrectly()
     {
         int expected = int.MaxValue;
-        var actual = new QueryVal<int>(expected);
+        var actual = new QueryVal(expected);
         Assert.AreEqual(expected, actual.Unwrap);
         Assert.IsInstanceOf<int>(actual.Unwrap);
     }
@@ -33,7 +33,7 @@ public class QueryValTests
     public void Ctor_WrapsDateTimeCorrectly()
     {
         DateTime expected = DateTime.Now;
-        var actual = new QueryVal<DateTime>(expected);
+        var actual = new QueryVal(expected);
         Assert.AreEqual(expected, actual.Unwrap);
         Assert.IsInstanceOf<DateTime>(actual.Unwrap);
     }
@@ -42,7 +42,7 @@ public class QueryValTests
     public void Ctor_WrapsDateTimeOffsetCorrectly()
     {
         DateTimeOffset expected = DateTimeOffset.Now;
-        var actual = new QueryVal<DateTimeOffset>(expected);
+        var actual = new QueryVal(expected);
         Assert.AreEqual(expected, actual.Unwrap);
         Assert.IsInstanceOf<DateTimeOffset>(actual.Unwrap);
     }
@@ -51,7 +51,7 @@ public class QueryValTests
     public void Ctor_WrapsStringCorrectly()
     {
         string expected = "test string";
-        var actual = new QueryVal<string>(expected);
+        var actual = new QueryVal(expected);
         Assert.AreEqual(expected, actual.Unwrap);
         Assert.IsInstanceOf<string>(actual.Unwrap);
     }
@@ -59,7 +59,7 @@ public class QueryValTests
     [Test]
     public void Ctor_WrapsNullCorrectly()
     {
-        var actual = new QueryVal<string?>(null);
+        var actual = new QueryVal(null);
         Assert.IsNull(actual.Unwrap);
     }
 
@@ -68,7 +68,7 @@ public class QueryValTests
     [TestCase("\n")]
     public void Ctor_WrapsWhitespaceString(string expected)
     {
-        var queryLiteral = new QueryVal<string>(expected);
+        var queryLiteral = new QueryVal(expected);
         Assert.AreEqual(expected, queryLiteral.Unwrap);
     }
 
@@ -78,10 +78,10 @@ public class QueryValTests
         string property1 = "value123";
         int property2 = 123;
         var poco = new TestPoco { Property1 = property1, Property2 = property2 };
-        var queryVal = new QueryVal<TestPoco>(poco);
-        Assert.IsInstanceOf<TestPoco>(queryVal.Unwrap);
-        Assert.AreEqual(property1, queryVal.Unwrap.Property1);
-        Assert.AreEqual(property2, queryVal.Unwrap.Property2);
+        var queryVal = new QueryVal(poco);
+        var unwrapped = (TestPoco)queryVal.Unwrap!;
+        Assert.AreEqual(property1, unwrapped.Property1);
+        Assert.AreEqual(property2, unwrapped.Property2);
     }
 
     [Test]
@@ -90,43 +90,46 @@ public class QueryValTests
         string value1 = "value123";
         int value2 = 123;
         var dictionary = new Dictionary<string, object> { { "key1", value1 }, { "key2", value2 } };
-        var queryVal = new QueryVal<IDictionary<string, object>>(dictionary);
-        Assert.AreEqual(2, queryVal.Unwrap.Count);
-        Assert.AreEqual(value1, queryVal.Unwrap["key1"]);
-        Assert.AreEqual(value2, queryVal.Unwrap["key2"]);
+        var queryVal = new QueryVal(dictionary);
+        var unwrapped = (Dictionary<string, object>)queryVal.Unwrap!;
+        Assert.AreEqual(2, unwrapped.Count);
+        Assert.AreEqual(value1, unwrapped["key1"]);
+        Assert.AreEqual(value2, unwrapped["key2"]);
     }
 
     [Test]
     public void Ctor_WrapsList()
     {
         var list = new List<int> { 57, 75 };
-        var queryVal = new QueryVal<List<int>>(list);
-        Assert.AreEqual(2, queryVal.Unwrap.Count);
-        Assert.AreEqual(57, queryVal.Unwrap[0]);
-        Assert.AreEqual(75, queryVal.Unwrap[1]);
+        var queryVal = new QueryVal(list);
+        var unwrapped = (List<int>)queryVal.Unwrap!;
+        Assert.AreEqual(2, unwrapped.Count);
+        Assert.AreEqual(57, unwrapped[0]);
+        Assert.AreEqual(75, unwrapped[1]);
     }
 
     [Test]
     public void ToString_ReturnsExpectedValue()
     {
-        var val = new QueryVal<int>(143);
+        var val = new QueryVal(143);
         Assert.AreEqual("QueryVal(143)", val.ToString());
     }
 
     [Test]
     public void GetHashCode_ReturnsConsistentValue()
     {
-        var val = new QueryVal<int>(143);
-        int hashCode1 = val.GetHashCode();
-        int hashCode2 = val.GetHashCode();
+        var val1 = new QueryVal(143);
+        var val2 = new QueryVal(143);
+        int hashCode1 = val1.GetHashCode();
+        int hashCode2 = val2.GetHashCode();
         Assert.AreEqual(hashCode1, hashCode2);
     }
 
     [Test]
     public void Equality_WithSameValue()
     {
-        var val1 = new QueryVal<int>(100);
-        var val2 = new QueryVal<int>(100);
+        var val1 = new QueryVal(100);
+        var val2 = new QueryVal(100);
 
         Assert.AreEqual(val1, val2);
     }
@@ -134,9 +137,9 @@ public class QueryValTests
     [Test]
     public void Inequality_WithDifferentValueOrType()
     {
-        var val1 = new QueryVal<int>(100);
-        var val2 = new QueryVal<int>(200);
-        var val3 = new QueryVal<short>(100);
+        var val1 = new QueryVal(100);
+        var val2 = new QueryVal(200);
+        var val3 = new QueryVal((short)100);
 
         Assert.AreNotEqual(val1, val2);
         Assert.AreNotEqual(val1, val3);
@@ -145,8 +148,8 @@ public class QueryValTests
     [Test]
     public void EqualityOperator_WithSameValue()
     {
-        var val1 = new QueryVal<int>(100);
-        var val2 = new QueryVal<int>(100);
+        var val1 = new QueryVal(100);
+        var val2 = new QueryVal(100);
 
         Assert.IsTrue(val1 == val2);
     }
@@ -154,8 +157,8 @@ public class QueryValTests
     [Test]
     public void InequalityOperator_WithDifferentValue()
     {
-        var val1 = new QueryVal<int>(100);
-        var val2 = new QueryVal<int>(200);
+        var val1 = new QueryVal(100);
+        var val2 = new QueryVal(200);
 
         Assert.IsTrue(val1 != val2);
     }
@@ -165,7 +168,7 @@ public class QueryValTests
     {
         int intValue = 5;
         string intExpected = $@"{{""value"":{{""@int"":""{intValue}""}}}}";
-        var intActual = new QueryVal<int>(intValue).Serialize();
+        var intActual = new QueryVal(intValue).Serialize();
 
         Assert.AreEqual(intExpected, intActual);
     }
@@ -175,7 +178,7 @@ public class QueryValTests
     {
         bool boolValue = true;
         string boolExpected = $@"{{""value"":{boolValue.ToString().ToLowerInvariant()}}}";
-        var boolActual = new QueryVal<bool>(boolValue).Serialize();
+        var boolActual = new QueryVal(boolValue).Serialize();
 
         Assert.AreEqual(boolExpected, boolActual);
     }

--- a/Fauna/Query/QueryStringHandler.cs
+++ b/Fauna/Query/QueryStringHandler.cs
@@ -30,11 +30,10 @@ public ref struct QueryStringHandler
     }
 
     /// <summary>
-    /// Appends a formatted value to the query. The value is wrapped as a <see cref="QueryVal{T}"/> or <see cref="QueryExpr"/> depending on its type.
+    /// Appends a formatted value to the query. The value is wrapped as a <see cref="QueryVal"/> or <see cref="QueryExpr"/> depending on its type.
     /// </summary>
-    /// <typeparam name="T">The type of the value to append.</typeparam>
     /// <param name="value">The value to append.</param>
-    public void AppendFormatted<T>(T value)
+    public void AppendFormatted(object? value)
     {
         if (value is QueryExpr expr)
         {
@@ -42,17 +41,8 @@ public ref struct QueryStringHandler
         }
         else
         {
-            fragments.Add(new QueryVal<T>(value));
+            fragments.Add(new QueryVal(value));
         }
-    }
-
-    /// <summary>
-    /// Appends a formatted object to the query. The object is wrapped as a <see cref="QueryVal{Object}"/>.
-    /// </summary>
-    /// <param name="value">The object to append.</param>
-    public void AppendFormatted(object value)
-    {
-        fragments.Add(new QueryVal<object>(value));
     }
 
     /// <summary>

--- a/Fauna/Query/QueryVal.cs
+++ b/Fauna/Query/QueryVal.cs
@@ -6,22 +6,21 @@ namespace Fauna;
 /// <summary>
 /// Represents a generic value holder for FQL queries. This class allows embedding values of various types into the query, with support for primitives, POCOs, and other types.
 /// </summary>
-/// <typeparam name="T">The type of the value to be embedded in the query.</typeparam>
-public sealed class QueryVal<T> : Query, IQueryFragment
+public sealed class QueryVal : Query, IQueryFragment
 {
+    /// <summary>
+    /// Gets the value of the specified type represented in the query.
+    /// </summary>
+    public object? Unwrap { get; }
+
     /// <summary>
     /// Initializes a new instance of the QueryVal class with the specified value.
     /// </summary>
     /// <param name="v">The value of the specified type to be represented in the query.</param>
-    public QueryVal(T v)
+    public QueryVal(object? v)
     {
         Unwrap = v;
     }
-
-    /// <summary>
-    /// Gets the value of the specified type represented in the query.
-    /// </summary>
-    public T Unwrap { get; }
 
     /// <summary>
     /// Serializes the query value.
@@ -41,7 +40,7 @@ public sealed class QueryVal<T> : Query, IQueryFragment
     /// </summary>
     /// <param name="o">The QueryVal to compare with the current QueryVal.</param>
     /// <returns>true if the specified QueryVal is equal to the current QueryVal; otherwise, false.</returns>
-    public override bool Equals(Query? o) => IsEqual(o as QueryVal<T>);
+    public override bool Equals(Query? o) => IsEqual(o as QueryVal);
 
     /// <summary>
     /// Determines whether the specified object is equal to the current QueryVal.
@@ -55,24 +54,24 @@ public sealed class QueryVal<T> : Query, IQueryFragment
             return true;
         }
 
-        if (o is null)
-        {
-            return false;
-        }
-
-        if (GetType() != o.GetType())
-        {
-            return false;
-        }
-
-        return IsEqual(o as QueryVal<T>);
+        return IsEqual(o as QueryVal);
     }
 
     /// <summary>
     /// The default hash function.
     /// </summary>
     /// <returns>A hash code for the current QueryVal.</returns>
-    public override int GetHashCode() => Unwrap != null ? EqualityComparer<T>.Default.GetHashCode(Unwrap) : 0;
+    public override int GetHashCode()
+    {
+        var hash = 31;
+
+        if (Unwrap is not null)
+        {
+            hash *= Unwrap.GetHashCode();
+        }
+
+        return hash;
+    }
 
     /// <summary>
     /// Returns a string that represents the current QueryVal.
@@ -86,7 +85,7 @@ public sealed class QueryVal<T> : Query, IQueryFragment
     /// <param name="left">The first QueryVal to compare.</param>
     /// <param name="right">The second QueryVal to compare.</param>
     /// <returns>true if left and right are equal; otherwise, false.</returns>
-    public static bool operator ==(QueryVal<T> left, QueryVal<T> right)
+    public static bool operator ==(QueryVal left, QueryVal right)
     {
         if (ReferenceEquals(left, right))
         {
@@ -107,18 +106,23 @@ public sealed class QueryVal<T> : Query, IQueryFragment
     /// <param name="left">The first QueryVal to compare.</param>
     /// <param name="right">The second QueryVal to compare.</param>
     /// <returns>true if left and right are not equal; otherwise, false.</returns>
-    public static bool operator !=(QueryVal<T> left, QueryVal<T> right)
+    public static bool operator !=(QueryVal left, QueryVal right)
     {
         return !(left == right);
     }
 
-    private bool IsEqual(QueryVal<T>? o)
+    private bool IsEqual(QueryVal? o)
     {
         if (o is null)
         {
             return false;
         }
 
-        return EqualityComparer<T>.Default.Equals(Unwrap, o.Unwrap);
+        if (Unwrap is null)
+        {
+            return (o.Unwrap is null) ? true : false;
+        }
+
+        return Unwrap.Equals(o.Unwrap);
     }
 }


### PR DESCRIPTION
We don't really need this, and it makes dynamic construction slightly more difficult.