### PR TITLE
serialize all ienumerables not just List

### DIFF
--- a/Fauna.Test/Serialization/Serializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializer.Tests.cs
@@ -112,6 +112,21 @@ public class SerializerTests
     }
 
     [Test]
+    public void SerializeArray()
+    {
+        var test = new object[]
+        {
+            42,
+            "foo bar",
+            new object[] {},
+            new Dictionary<string, object>()
+        };
+
+        var actual = Serialize(test);
+        Assert.AreEqual(@"[{""@int"":""42""},""foo bar"",[],{}]", actual);
+    }
+
+    [Test]
     public void SerializeClass()
     {
         var test = new Person();

--- a/Fauna/Serialization/Serializer.cs
+++ b/Fauna/Serialization/Serializer.cs
@@ -180,7 +180,7 @@ public static partial class Serializer
             case Dictionary<string, object> d:
                 SerializeIDictionaryInternal(writer, d, context);
                 break;
-            case List<object> e:
+            case IEnumerable<object> e:
                 writer.WriteStartArray();
                 foreach (var o in e)
                 {


### PR DESCRIPTION
I _think_ it makes sense to just generically handle all ienumerables this way. Fixes an issue where arrays would fall into the class deserialization path, and StackOverflow (arrays have a property which points back to themselves...)