### PR TITLE
Remove type hint from public serialize contract

### DIFF
--- a/Fauna/Serialization/Serializer.cs
+++ b/Fauna/Serialization/Serializer.cs
@@ -18,156 +18,160 @@ public static partial class Serializer
     /// <summary>
     /// Serializes an object to a Fauna compatible format.
     /// </summary>
-    /// <param name="context">The context for serialization.</param>
-    /// <param name="writer">The writer to serialize the object to.</param>
-    /// <param name="obj">The object to serialize.</param>
-    /// <param name="typeHint">Optional type hint for the object.</param>
+    /// <param name="ctx">The context for serialization.</param>
+    /// <param name="w">The writer to serialize the object to.</param>
+    /// <param name="o">The object to serialize.</param>
     /// <exception cref="SerializationException">Thrown when serialization fails.</exception>
-    public static void Serialize(MappingContext context, Utf8FaunaWriter writer, object? obj, FaunaType? typeHint = null)
+    public static void Serialize(MappingContext ctx, Utf8FaunaWriter w, object? o)
     {
-        if (typeHint != null)
-        {
-            if (obj is null) throw new ArgumentNullException(nameof(obj));
+        SerializeValueInternal(ctx, w, o);
+    }
 
-            switch (typeHint)
+    private static void SerializeValueInternal(MappingContext ctx, Utf8FaunaWriter w, object? o, FaunaType? ty = null)
+    {
+        if (ty != null)
+        {
+            if (o is null) throw new ArgumentNullException(nameof(o));
+
+            switch (ty)
             {
                 case FaunaType.Int:
-                    if (obj is byte or sbyte or short or ushort or int)
+                    if (o is byte or sbyte or short or ushort or int)
                     {
-                        var int32 = Convert.ToInt32(obj);
-                        writer.WriteIntValue(int32);
+                        var int32 = Convert.ToInt32(o);
+                        w.WriteIntValue(int32);
                     }
                     else
                     {
-                        throw new SerializationException($"Unsupported Int conversion. Provided value must be a byte, sbyte, short, ushort, or int but was a {obj.GetType()}");
+                        throw new SerializationException($"Unsupported Int conversion. Provided value must be a byte, sbyte, short, ushort, or int but was a {o.GetType()}");
                     }
                     break;
                 case FaunaType.Long:
-                    if (obj is byte or sbyte or short or ushort or int or uint or long)
+                    if (o is byte or sbyte or short or ushort or int or uint or long)
                     {
-                        var int64 = Convert.ToInt64(obj);
-                        writer.WriteLongValue(int64);
+                        var int64 = Convert.ToInt64(o);
+                        w.WriteLongValue(int64);
                     }
                     else
                     {
-                        throw new SerializationException($"Unsupported Long conversion. Provided value must be a byte, sbyte, short, ushort, int, uint, or long but was a {obj.GetType()}");
+                        throw new SerializationException($"Unsupported Long conversion. Provided value must be a byte, sbyte, short, ushort, int, uint, or long but was a {o.GetType()}");
                     }
                     break;
                 case FaunaType.Double:
-                    switch (obj)
+                    switch (o)
                     {
                         case float or double or short or int or long:
                             {
-                                var dub = Convert.ToDouble(obj);
-                                writer.WriteDoubleValue(dub);
+                                var dub = Convert.ToDouble(o);
+                                w.WriteDoubleValue(dub);
                                 break;
                             }
                         default:
-                            throw new SerializationException($"Unsupported Double conversion. Provided value must be a short, int, long, float, or double, but was a {obj.GetType()}");
+                            throw new SerializationException($"Unsupported Double conversion. Provided value must be a short, int, long, float, or double, but was a {o.GetType()}");
                     }
                     break;
                 case FaunaType.String:
-                    writer.WriteStringValue(obj.ToString() ?? string.Empty);
+                    w.WriteStringValue(o.ToString() ?? string.Empty);
                     break;
                 case FaunaType.Date:
-                    switch (obj)
+                    switch (o)
                     {
                         case DateTime v:
-                            writer.WriteDateValue(v);
+                            w.WriteDateValue(v);
                             break;
                         case DateOnly v:
-                            writer.WriteDateValue(v);
+                            w.WriteDateValue(v);
                             break;
                         case DateTimeOffset v:
-                            writer.WriteDateValue(v);
+                            w.WriteDateValue(v);
                             break;
                         default:
-                            throw new SerializationException($"Unsupported Date conversion. Provided value must be a DateTime, DateTimeOffset, or DateOnly but was a {obj.GetType()}");
+                            throw new SerializationException($"Unsupported Date conversion. Provided value must be a DateTime, DateTimeOffset, or DateOnly but was a {o.GetType()}");
                     }
                     break;
                 case FaunaType.Time:
-                    switch (obj)
+                    switch (o)
                     {
                         case DateTime v:
-                            writer.WriteTimeValue(v);
+                            w.WriteTimeValue(v);
                             break;
                         case DateTimeOffset v:
-                            writer.WriteTimeValue(v);
+                            w.WriteTimeValue(v);
                             break;
                         default:
-                            throw new SerializationException($"Unsupported Time conversion. Provided value must be a DateTime or DateTimeOffset but was a {obj.GetType()}");
+                            throw new SerializationException($"Unsupported Time conversion. Provided value must be a DateTime or DateTimeOffset but was a {o.GetType()}");
                     }
                     break;
                 case FaunaType.Boolean:
-                    if (obj is bool b)
+                    if (o is bool b)
                     {
-                        writer.WriteBooleanValue(b);
+                        w.WriteBooleanValue(b);
                     }
                     else
                     {
-                        throw new SerializationException($"Unsupported Boolean conversion. Provided value must be a bool but was a {obj.GetType()}");
+                        throw new SerializationException($"Unsupported Boolean conversion. Provided value must be a bool but was a {o.GetType()}");
                     }
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(typeHint), typeHint, null);
+                    throw new ArgumentOutOfRangeException(nameof(ty), ty, null);
             }
         }
         else
         {
-            switch (obj)
+            switch (o)
             {
                 case null:
-                    writer.WriteNullValue();
+                    w.WriteNullValue();
                     break;
                 case byte v:
-                    writer.WriteIntValue(v);
+                    w.WriteIntValue(v);
                     break;
                 case sbyte v:
-                    writer.WriteIntValue(v);
+                    w.WriteIntValue(v);
                     break;
                 case ushort v:
-                    writer.WriteIntValue(v);
+                    w.WriteIntValue(v);
                     break;
                 case short v:
-                    writer.WriteIntValue(v);
+                    w.WriteIntValue(v);
                     break;
                 case int v:
-                    writer.WriteIntValue(v);
+                    w.WriteIntValue(v);
                     break;
                 case uint v:
-                    writer.WriteLongValue(v);
+                    w.WriteLongValue(v);
                     break;
                 case long v:
-                    writer.WriteLongValue(v);
+                    w.WriteLongValue(v);
                     break;
                 case float v:
-                    writer.WriteDoubleValue(v);
+                    w.WriteDoubleValue(v);
                     break;
                 case double v:
-                    writer.WriteDoubleValue(v);
+                    w.WriteDoubleValue(v);
                     break;
                 case decimal:
                     throw new SerializationException("Decimals are unsupported due to potential loss of precision.");
                 case bool v:
-                    writer.WriteBooleanValue(v);
+                    w.WriteBooleanValue(v);
                     break;
                 case string v:
-                    writer.WriteStringValue(v);
+                    w.WriteStringValue(v);
                     break;
                 case Module v:
-                    writer.WriteModuleValue(v);
+                    w.WriteModuleValue(v);
                     break;
                 case DateTime v:
-                    writer.WriteTimeValue(v);
+                    w.WriteTimeValue(v);
                     break;
                 case DateTimeOffset v:
-                    writer.WriteTimeValue(v);
+                    w.WriteTimeValue(v);
                     break;
                 case DateOnly v:
-                    writer.WriteDateValue(v);
+                    w.WriteDateValue(v);
                     break;
                 default:
-                    SerializeObjectInternal(writer, obj, context);
+                    SerializeObjectInternal(w, o, ctx);
                     break;
             }
         }
@@ -184,7 +188,7 @@ public static partial class Serializer
                 writer.WriteStartArray();
                 foreach (var o in e)
                 {
-                    Serialize(context, writer, o);
+                    SerializeValueInternal(context, writer, o);
                 }
                 writer.WriteEndArray();
                 break;
@@ -218,7 +222,7 @@ public static partial class Serializer
         {
             writer.WriteFieldName(field.Name!);
             var v = field.Property.GetValue(obj);
-            Serialize(context, writer, v, field.FaunaTypeHint);
+            SerializeValueInternal(context, writer, v, field.FaunaTypeHint);
         }
         if (shouldEscape) writer.WriteEndEscapedObject(); else writer.WriteEndObject();
     }


### PR DESCRIPTION
Type hint is an implementation detail of the MappingContext, so remove it from the external contract.