### PR TITLE
@date as DateOnly

### DIFF
--- a/Fauna.Test/Serialization/Deserializer.Tests.cs
+++ b/Fauna.Test/Serialization/Deserializer.Tests.cs
@@ -61,7 +61,7 @@ public class DeserializerTests
             {@"{""@int"":""42""}", 42},
             {@"{""@long"":""42""}", 42L},
             {@"{""@double"": ""1.2""}", 1.2d},
-            {@"{""@date"": ""2023-12-03""}", new DateTime(2023, 12, 3)},
+            {@"{""@date"": ""2023-12-03""}", new DateOnly(2023, 12, 3)},
             {@"{""@time"": ""2023-12-03T05:52:10.000001-09:00""}", new DateTime(2023, 12, 3, 14, 52, 10, 0, DateTimeKind.Utc).AddTicks(10).ToLocalTime()},
             {"true", true},
             {"false", false},
@@ -116,8 +116,8 @@ public class DeserializerTests
     [Test]
     public void DeserializeDateGeneric()
     {
-        var result = Deserialize<DateTime>(@"{""@date"": ""2023-12-03""}");
-        Assert.AreEqual(new DateTime(2023, 12, 3), result);
+        var result = Deserialize<DateOnly>(@"{""@date"": ""2023-12-03""}");
+        Assert.AreEqual(new DateOnly(2023, 12, 3), result);
     }
 
     [Test]
@@ -376,7 +376,7 @@ public class DeserializerTests
             { "anInt", 2147483647 },
             { "aLong", 9223372036854775807 },
             { "aDouble", 3.14159d },
-            { "aDate", new DateTime(2023, 12, 3) },
+            { "aDate", new DateOnly(2023, 12, 3) },
             { "aTime", new DateTime(2023, 12, 3, 14, 52, 10, 1, DateTimeKind.Utc).AddTicks(10).ToLocalTime() },
             { "true", true },
             { "false", false },

--- a/Fauna.Test/Serialization/Utf8FaunaReader.Tests.cs
+++ b/Fauna.Test/Serialization/Utf8FaunaReader.Tests.cs
@@ -169,7 +169,7 @@ public class Utf8FaunaReaderTests
         var reader = new Utf8FaunaReader(s);
         var expectedTokens = new List<Tuple<TokenType, object?>>()
         {
-            new(TokenType.Date, new DateTime(2023, 12, 3))
+            new(TokenType.Date, new DateOnly(2023, 12, 3))
         };
 
         AssertReader(reader, expectedTokens);
@@ -392,7 +392,7 @@ public class Utf8FaunaReaderTests
             new(TokenType.Double, 0.1M),
 
             new(TokenType.FieldName, "aDate"),
-            new(TokenType.Date, new DateTime(2023, 12, 3)),
+            new(TokenType.Date, new DateOnly(2023, 12, 3)),
 
             new(TokenType.FieldName, "aTime"),
             new(TokenType.Time, new DateTime(2023, 12, 3, 14, 52, 10, 1, DateTimeKind.Utc).AddTicks(10).ToLocalTime()),
@@ -464,7 +464,7 @@ public class Utf8FaunaReaderTests
 
             new(TokenType.Double, 0.1M),
 
-            new(TokenType.Date, new DateTime(2023, 12, 3)),
+            new(TokenType.Date, new DateOnly(2023, 12, 3)),
 
             new(TokenType.Time, new DateTime(2023, 12, 3, 14, 52, 10, 1, DateTimeKind.Utc).AddTicks(10).ToLocalTime()),
 

--- a/Fauna/Serialization/Deserializer.cs
+++ b/Fauna/Serialization/Deserializer.cs
@@ -18,6 +18,7 @@ public static class Deserializer
     private static readonly CheckedDeserializer<int> _int = new();
     private static readonly LongDeserializer _long = new();
     private static readonly CheckedDeserializer<double> _double = new();
+    private static readonly CheckedDeserializer<DateOnly> _dateOnly = new();
     private static readonly CheckedDeserializer<DateTime> _dateTime = new();
     private static readonly CheckedDeserializer<bool> _bool = new();
     private static readonly CheckedDeserializer<Module> _module = new();
@@ -54,6 +55,7 @@ public static class Deserializer
         if (targetType == typeof(int)) return _int;
         if (targetType == typeof(long)) return _long;
         if (targetType == typeof(double)) return _double;
+        if (targetType == typeof(DateOnly)) return _dateOnly;
         if (targetType == typeof(DateTime)) return _dateTime;
         if (targetType == typeof(bool)) return _bool;
         if (targetType == typeof(Module)) return _module;

--- a/Fauna/Serialization/Utf8FaunaReader.cs
+++ b/Fauna/Serialization/Utf8FaunaReader.cs
@@ -210,16 +210,16 @@ public ref struct Utf8FaunaReader
     }
 
     /// <summary>
-    /// Retrieves a DateTime value from the current token.
+    /// Retrieves a DateOnly value from the current token.
     /// </summary>
-    /// <returns>A DateTime representation of the current token's value.</returns>
-    public DateTime GetDate()
+    /// <returns>A DateOnly representation of the current token's value.</returns>
+    public DateOnly GetDate()
     {
         ValidateTaggedType(TokenType.Date);
 
         try
         {
-            return DateTime.Parse(_taggedTokenValue!);
+            return DateOnly.Parse(_taggedTokenValue!);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Instead of deserializing `@date` to DateTime, we should deserialize to DateOnly.

Ideally we'd be able to handle date and time variants, i.e. if a user specifies a DateTime type for a `@date` we would do that, but I don't think that's necessary for beta. It does maintain an asymmetry where users can serialize date/time types to whatever they choose, but cannot deserialize them as they choose.