### PR TITLE
Fix all versions list

### DIFF
--- a/concourse/scripts/publish-docs.sh
+++ b/concourse/scripts/publish-docs.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -eou
 cd ./repo.git
+REPO_GIT_DIR="$(pwd)/.git"
 
 apk add xmlstarlet
 PACKAGE_VERSION=$(xml sel -t -v "/Project/PropertyGroup/Version" ./Fauna/Fauna.csproj)
@@ -19,7 +20,7 @@ echo "</section>" >> index.html
 
 echo "<section style=\"margin: 20px\">" >> index.html
 echo "<header>All Versions</header>" >> index.html
-git tag -l --sort=-v:refname | awk '{print "<li><a href=\"https://fauna.github.io/fauna-dotnet/"$0"\">"$0"</a></li>"}' >> index.html
+git --git-dir "$REPO_GIT_DIR" tag -l --sort=-v:refname | awk '{print "<li><a href=\"https://fauna.github.io/fauna-dotnet/"$0"\">"$0"</a></li>"}' >> index.html
 echo "</section>" >> index.html
 
 mkdir "${PACKAGE_VERSION}"


### PR DESCRIPTION
We're in the docs clone when we try to get the git tags, which don't exist there. Instead, use the _real_ repo.