### PR TITLE
Add support for nullable struct deserialization

### DIFF
--- a/Fauna.Test/Serialization/Deserializer.Tests.cs
+++ b/Fauna.Test/Serialization/Deserializer.Tests.cs
@@ -932,4 +932,28 @@ public class DeserializerTests
         Assert.AreEqual(40, result.Data[1].Age);
         Assert.AreEqual("next_page_cursor", result.After);
     }
+
+    [Test]
+    public void DeserializeNullableStructAsValue()
+    {
+        const string given = @"{
+            ""val"":{""@int"":""42""}
+        }";
+
+        var result = Deserialize<NullableInt>(given);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(42, result.Val);
+    }
+
+    [Test]
+    public void DeserializeNullableStructAsNull()
+    {
+        const string given = @"{
+            ""val"": null
+        }";
+
+        var result = Deserialize<NullableInt>(given);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(null, result.Val);
+    }
 }

--- a/Fauna.Test/Serialization/Serializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializer.Tests.cs
@@ -294,4 +294,22 @@ public class SerializerTests
             Assert.AreEqual(expected, actual);
         }
     }
+
+    [Test]
+    public void SerializeNullableStructAsNull()
+    {
+        var i = new int?();
+
+        var actual = Serialize(i);
+        Assert.AreEqual("null", actual);
+    }
+
+    [Test]
+    public void SerializeNullableStructAsValue()
+    {
+        var i = new int?(42);
+
+        var actual = Serialize(i);
+        Assert.AreEqual(@"{""@int"":""42""}", actual);
+    }
 }

--- a/Fauna.Test/Serialization/TestClasses.cs
+++ b/Fauna.Test/Serialization/TestClasses.cs
@@ -9,6 +9,11 @@ class Person
     public int Age { get; set; } = 61;
 }
 
+class NullableInt
+{
+    public int? Val { get; set; }
+}
+
 [Object]
 class ClassForDocument
 {

--- a/Fauna/Mapping/FieldInfo.cs
+++ b/Fauna/Mapping/FieldInfo.cs
@@ -55,7 +55,7 @@ public sealed class FieldInfo
                 if (_deserializer is null)
                 {
                     _deserializer = Fauna.Serialization.Deserializer.Generate(_ctx, Type);
-                    if (IsNullable)
+                    if (IsNullable && _deserializer.GetType().GetGenericTypeDefinition() != typeof(NullableStructDeserializer<>))
                     {
                         var deserType = typeof(NullableDeserializer<>).MakeGenericType(new[] { Type });
                         var deser = Activator.CreateInstance(deserType, new[] { _deserializer });

--- a/Fauna/Serialization/NullableStructDeserializer.cs
+++ b/Fauna/Serialization/NullableStructDeserializer.cs
@@ -1,0 +1,23 @@
+using Fauna.Mapping;
+
+namespace Fauna.Serialization;
+
+internal class NullableStructDeserializer<T> : BaseDeserializer<T?> where T : struct
+{
+    private readonly IDeserializer<T> _inner;
+
+    public NullableStructDeserializer(IDeserializer<T> inner)
+    {
+        _inner = inner;
+    }
+
+    public override T? Deserialize(MappingContext context, ref Utf8FaunaReader reader)
+    {
+        if (reader.CurrentTokenType == TokenType.Null)
+        {
+            return new T?();
+        }
+
+        return _inner.Deserialize(context, ref reader);
+    }
+}


### PR DESCRIPTION
### Problem
When deserializing into a nullable struct, the deserializer falls through and fails. This was masked in unit tests because the nullable unit test uses GenerateNullable directly rather than going through the primary deserialize path.

```
System.ArgumentException : Unsupported deserialization target type System.Nullable`1[System.Int32]
```

### Solution
At first I tried to build and use a NullableDeserializer in the primary deserialize entry point, but the default(T) behavior resulted in a Nullable<int> to be set to 0 in the null case. After several attempts at getting this to work, I worked on a separate solution.

Implement NullableStructDeserializer that constrains the generic to structs. This allowed the default case to return a new Nullable<T>, which results in the expected behavior.