### PR TITLE
Remove FaunaType override attribute

### DIFF
--- a/Fauna.Test/Serialization/Serializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializer.Tests.cs
@@ -139,7 +139,7 @@ public class SerializerTests
     {
         var test = new PersonWithAttributes();
         var actual = Serialize(test);
-        Assert.AreEqual(@"{""first_name"":""Baz"",""last_name"":""Luhrmann"",""age"":{""@long"":""61""}}", actual);
+        Assert.AreEqual(@"{""first_name"":""Baz"",""last_name"":""Luhrmann"",""age"":{""@int"":""61""}}", actual);
     }
 
     [Test]
@@ -164,52 +164,6 @@ public class SerializerTests
             var actual = Serialize(test);
             Assert.AreEqual(expected, actual);
         }
-    }
-
-    [Test]
-    public void SerializeClassWithTypeConversions()
-    {
-        var test = new PersonWithTypeOverrides();
-        var expectedWithWhitespace = @"
-                       {
-                           ""short_to_long"": {""@long"": ""10""},
-                           ""ushort_to_long"": {""@long"": ""11""},
-                           ""byte_to_long"": {""@long"": ""12""},
-                           ""sbyte_to_long"": {""@long"": ""13""},
-                           ""int_to_long"": {""@long"": ""20""},
-                           ""uint_to_long"": {""@long"": ""21""},
-                           ""long_to_long"": {""@long"": ""30""},
-                           ""short_to_int"": {""@int"": ""40""},
-                           ""ushort_to_int"": {""@int"": ""41""},
-                           ""byte_to_int"": {""@int"": ""42""},
-                           ""sbyte_to_int"": {""@int"": ""43""},
-                           ""int_to_int"": {""@int"": ""50""},
-                           ""short_to_double"": {""@double"": ""60""},
-                           ""int_to_double"": {""@double"": ""70""},
-                           ""long_to_double"": {""@double"": ""80""},
-                           ""double_to_double"": {""@double"": ""10.1""},
-                           ""float_to_double"": {""@double"": ""1.344499945640564""},
-                           ""true_to_true"": true,
-                           ""false_to_false"": false,
-                           ""class_to_string"": ""TheThing"",
-                           ""string_to_string"": ""aString"",
-                           ""datetime_to_date"": {""@date"": ""2023-12-13""},
-                           ""dateonly_to_date"": {""@date"": ""2023-12-13""},
-                           ""datetimeoffset_to_date"": {""@date"": ""2023-12-13""},
-                           ""datetime_to_time"": {""@time"":""2023-12-13T12:12:12.0010010Z""},
-                           ""datetimeoffset_to_time"": {""@time"":""2023-12-13T12:12:12.0010010\u002B00:00""}
-                       }
-                       ";
-        var expected = Regex.Replace(expectedWithWhitespace, @"\s", string.Empty);
-        var actual = Serialize(test);
-        Assert.AreEqual(expected, actual);
-    }
-
-    [Test]
-    public void SerializeObjectWithInvalidTypeHint()
-    {
-        var obj = new ClassWithInvalidPropertyTypeHint();
-        Assert.Throws<SerializationException>(() => Serialize(obj));
     }
 
     [Test]
@@ -263,10 +217,16 @@ public class SerializerTests
         {
             { short.MaxValue, @"{""@int"":""32767""}" },
             { short.MinValue, @"{""@int"":""-32768""}" },
+            { ushort.MaxValue, @"{""@int"":""65535""}" },
+            { ushort.MinValue, @"{""@int"":""0""}" },
             { int.MaxValue, @"{""@int"":""2147483647""}" },
             { int.MinValue, @"{""@int"":""-2147483648""}" },
+            { uint.MaxValue, @"{""@long"":""4294967295""}" },
+            { uint.MinValue, @"{""@long"":""0""}" },
             { long.MaxValue, @"{""@long"":""9223372036854775807""}" },
             { long.MinValue, @"{""@long"":""-9223372036854775808""}" },
+            { float.MaxValue, @"{""@double"":""3.4028234663852886E\u002B38""}" },
+            { float.MinValue, @"{""@double"":""-3.4028234663852886E\u002B38""}" },
             { double.MaxValue, @"{""@double"":""1.7976931348623157E\u002B308""}" },
             { double.MinValue, @"{""@double"":""-1.7976931348623157E\u002B308""}" }
         };

--- a/Fauna.Test/Serialization/TestClasses.cs
+++ b/Fauna.Test/Serialization/TestClasses.cs
@@ -46,15 +46,8 @@ class PersonWithAttributes
 {
     [Field("first_name")] public string? FirstName { get; set; } = "Baz";
     [Field("last_name")] public string? LastName { get; set; } = "Luhrmann";
-    [Field("age", FaunaType.Long)] public int Age { get; set; } = 61;
+    [Field("age")] public int Age { get; set; } = 61;
     public string? Ignored { get; set; }
-}
-
-
-[Object]
-class ClassWithInvalidPropertyTypeHint
-{
-    [Field("first_name", FaunaType.Int)] public string FirstName { get; set; } = "NotANumber";
 }
 
 class ClassWithFieldAttributeAndWithoutObjectAttribute
@@ -82,57 +75,6 @@ class ThingWithStringOverride
         return Name;
     }
 }
-
-[Object]
-class PersonWithTypeOverrides
-{
-    // Long Conversions
-    [Field("short_to_long", FaunaType.Long)] public short? ShortToLong { get; set; } = 10;
-    [Field("ushort_to_long", FaunaType.Long)] public ushort? UShortToLong { get; set; } = 11;
-    [Field("byte_to_long", FaunaType.Long)] public byte? ByteToLong { get; set; } = 12;
-    [Field("sbyte_to_long", FaunaType.Long)] public sbyte? SByteToLong { get; set; } = 13;
-    [Field("int_to_long", FaunaType.Long)] public int? IntToLong { get; set; } = 20;
-    [Field("uint_to_long", FaunaType.Long)] public uint? UIntToLong { get; set; } = 21;
-    [Field("long_to_long", FaunaType.Long)] public long? LongToLong { get; set; } = 30L;
-
-    // Int Conversions
-    [Field("short_to_int", FaunaType.Int)] public short? ShortToInt { get; set; } = 40;
-    [Field("ushort_to_int", FaunaType.Int)] public short? UShortToInt { get; set; } = 41;
-    [Field("byte_to_int", FaunaType.Int)] public byte? ByteToInt { get; set; } = 42;
-    [Field("sbyte_to_int", FaunaType.Int)] public sbyte? SByteToInt { get; set; } = 43;
-    [Field("int_to_int", FaunaType.Int)] public int? IntToInt { get; set; } = 50;
-
-    // Double Conversions
-    [Field("short_to_double", FaunaType.Double)] public short? ShortToDouble { get; set; } = 60;
-    [Field("int_to_double", FaunaType.Double)] public int? IntToDouble { get; set; } = 70;
-    [Field("long_to_double", FaunaType.Double)] public long? LongToDouble { get; set; } = 80L;
-    [Field("double_to_double", FaunaType.Double)] public double? DoubleToDouble { get; set; } = 10.1d;
-    [Field("float_to_double", FaunaType.Double)] public float? FloatToDouble { get; set; } = 1.3445f;
-
-    // Bool conversions
-    [Field("true_to_true", FaunaType.Boolean)] public bool? TrueToTrue { get; set; } = true;
-    [Field("false_to_false", FaunaType.Boolean)] public bool? FalseToFalse { get; set; } = false;
-
-    // String conversions
-    [Field("class_to_string", FaunaType.String)]
-    public ThingWithStringOverride? ThingToString { get; set; } = new();
-    [Field("string_to_string", FaunaType.String)] public string? StringToString { get; set; } = "aString";
-
-    // Date conversions
-    [Field("datetime_to_date", FaunaType.Date)]
-    public DateTime? DateTimeToDate { get; set; } = DateTime.Parse("2023-12-13T12:12:12.001001Z");
-    [Field("dateonly_to_date", FaunaType.Date)]
-    public DateOnly? DateOnlyToDate { get; set; } = new DateOnly(2023, 12, 13);
-    [Field("datetimeoffset_to_date", FaunaType.Date)]
-    public DateTimeOffset? DateTimeOffsetToDate { get; set; } = DateTimeOffset.Parse("2023-12-13T12:12:12.001001Z");
-
-    // Time conversions
-    [Field("datetime_to_time", FaunaType.Time)]
-    public DateTime? DateTimeToTime { get; set; } = DateTime.Parse("2023-12-13T12:12:12.001001Z");
-    [Field("datetimeoffset_to_time", FaunaType.Time)]
-    public DateTimeOffset? DateTimeOffsetToTime { get; set; } = new DateTimeOffset(DateTime.Parse("2023-12-13T12:12:12.001001Z"));
-}
-
 
 [Object]
 class PersonWithIntConflict

--- a/Fauna/Mapping/Attributes.cs
+++ b/Fauna/Mapping/Attributes.cs
@@ -1,18 +1,5 @@
 namespace Fauna.Mapping.Attributes;
 
-/// <summary>
-/// Enumerates the different types of data that can be stored in Fauna.
-/// </summary>
-public enum FaunaType
-{
-    Int,
-    Long,
-    Double,
-    String,
-    Date,
-    Time,
-    Boolean,
-}
 
 /// <summary>
 /// Attribute used to indicate that a class represents a Fauna document or struct.
@@ -29,23 +16,11 @@ public class ObjectAttribute : Attribute
 public class FieldAttribute : Attribute
 {
     internal readonly string? Name;
-    internal readonly FaunaType? Type;
 
     public FieldAttribute() { }
 
     public FieldAttribute(string name)
     {
         Name = name;
-    }
-
-    public FieldAttribute(FaunaType type)
-    {
-        Type = type;
-    }
-
-    public FieldAttribute(string name, FaunaType type)
-    {
-        Name = name;
-        Type = type;
     }
 }

--- a/Fauna/Mapping/FieldInfo.cs
+++ b/Fauna/Mapping/FieldInfo.cs
@@ -18,10 +18,6 @@ public sealed class FieldInfo
     /// </summary>
     public PropertyInfo Property { get; }
     /// <summary>
-    /// Indicates which fauna type the value should serialize into.
-    /// </summary>
-    public FaunaType? FaunaTypeHint { get; }
-    /// <summary>
     /// The <see cref="Type"/> that the field should deserialize into.
     /// </summary>
     public Type Type { get; }
@@ -39,7 +35,6 @@ public sealed class FieldInfo
         var nullInfo = nullCtx.Create(prop);
 
         Name = attr.Name ?? FieldName.Canonical(prop.Name);
-        FaunaTypeHint = attr.Type;
         Property = prop;
         Type = prop.PropertyType;
         IsNullable = nullInfo.WriteState is NullabilityState.Nullable;

--- a/Fauna/Serialization/Serializer.cs
+++ b/Fauna/Serialization/Serializer.cs
@@ -27,153 +27,63 @@ public static partial class Serializer
         SerializeValueInternal(ctx, w, o);
     }
 
-    private static void SerializeValueInternal(MappingContext ctx, Utf8FaunaWriter w, object? o, FaunaType? ty = null)
+    private static void SerializeValueInternal(MappingContext ctx, Utf8FaunaWriter w, object? o)
     {
-        if (ty != null)
+        switch (o)
         {
-            if (o is null) throw new ArgumentNullException(nameof(o));
-
-            switch (ty)
-            {
-                case FaunaType.Int:
-                    if (o is byte or sbyte or short or ushort or int)
-                    {
-                        var int32 = Convert.ToInt32(o);
-                        w.WriteIntValue(int32);
-                    }
-                    else
-                    {
-                        throw new SerializationException($"Unsupported Int conversion. Provided value must be a byte, sbyte, short, ushort, or int but was a {o.GetType()}");
-                    }
-                    break;
-                case FaunaType.Long:
-                    if (o is byte or sbyte or short or ushort or int or uint or long)
-                    {
-                        var int64 = Convert.ToInt64(o);
-                        w.WriteLongValue(int64);
-                    }
-                    else
-                    {
-                        throw new SerializationException($"Unsupported Long conversion. Provided value must be a byte, sbyte, short, ushort, int, uint, or long but was a {o.GetType()}");
-                    }
-                    break;
-                case FaunaType.Double:
-                    switch (o)
-                    {
-                        case float or double or short or int or long:
-                            {
-                                var dub = Convert.ToDouble(o);
-                                w.WriteDoubleValue(dub);
-                                break;
-                            }
-                        default:
-                            throw new SerializationException($"Unsupported Double conversion. Provided value must be a short, int, long, float, or double, but was a {o.GetType()}");
-                    }
-                    break;
-                case FaunaType.String:
-                    w.WriteStringValue(o.ToString() ?? string.Empty);
-                    break;
-                case FaunaType.Date:
-                    switch (o)
-                    {
-                        case DateTime v:
-                            w.WriteDateValue(v);
-                            break;
-                        case DateOnly v:
-                            w.WriteDateValue(v);
-                            break;
-                        case DateTimeOffset v:
-                            w.WriteDateValue(v);
-                            break;
-                        default:
-                            throw new SerializationException($"Unsupported Date conversion. Provided value must be a DateTime, DateTimeOffset, or DateOnly but was a {o.GetType()}");
-                    }
-                    break;
-                case FaunaType.Time:
-                    switch (o)
-                    {
-                        case DateTime v:
-                            w.WriteTimeValue(v);
-                            break;
-                        case DateTimeOffset v:
-                            w.WriteTimeValue(v);
-                            break;
-                        default:
-                            throw new SerializationException($"Unsupported Time conversion. Provided value must be a DateTime or DateTimeOffset but was a {o.GetType()}");
-                    }
-                    break;
-                case FaunaType.Boolean:
-                    if (o is bool b)
-                    {
-                        w.WriteBooleanValue(b);
-                    }
-                    else
-                    {
-                        throw new SerializationException($"Unsupported Boolean conversion. Provided value must be a bool but was a {o.GetType()}");
-                    }
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(ty), ty, null);
-            }
-        }
-        else
-        {
-            switch (o)
-            {
-                case null:
-                    w.WriteNullValue();
-                    break;
-                case byte v:
-                    w.WriteIntValue(v);
-                    break;
-                case sbyte v:
-                    w.WriteIntValue(v);
-                    break;
-                case ushort v:
-                    w.WriteIntValue(v);
-                    break;
-                case short v:
-                    w.WriteIntValue(v);
-                    break;
-                case int v:
-                    w.WriteIntValue(v);
-                    break;
-                case uint v:
-                    w.WriteLongValue(v);
-                    break;
-                case long v:
-                    w.WriteLongValue(v);
-                    break;
-                case float v:
-                    w.WriteDoubleValue(v);
-                    break;
-                case double v:
-                    w.WriteDoubleValue(v);
-                    break;
-                case decimal:
-                    throw new SerializationException("Decimals are unsupported due to potential loss of precision.");
-                case bool v:
-                    w.WriteBooleanValue(v);
-                    break;
-                case string v:
-                    w.WriteStringValue(v);
-                    break;
-                case Module v:
-                    w.WriteModuleValue(v);
-                    break;
-                case DateTime v:
-                    w.WriteTimeValue(v);
-                    break;
-                case DateTimeOffset v:
-                    w.WriteTimeValue(v);
-                    break;
-                case DateOnly v:
-                    w.WriteDateValue(v);
-                    break;
-                default:
-                    SerializeObjectInternal(w, o, ctx);
-                    break;
-            }
+            case null:
+                w.WriteNullValue();
+                break;
+            case byte v:
+                w.WriteIntValue(v);
+                break;
+            case sbyte v:
+                w.WriteIntValue(v);
+                break;
+            case ushort v:
+                w.WriteIntValue(v);
+                break;
+            case short v:
+                w.WriteIntValue(v);
+                break;
+            case int v:
+                w.WriteIntValue(v);
+                break;
+            case uint v:
+                w.WriteLongValue(v);
+                break;
+            case long v:
+                w.WriteLongValue(v);
+                break;
+            case float v:
+                w.WriteDoubleValue(v);
+                break;
+            case double v:
+                w.WriteDoubleValue(v);
+                break;
+            case decimal:
+                throw new SerializationException("Decimals are unsupported due to potential loss of precision.");
+            case bool v:
+                w.WriteBooleanValue(v);
+                break;
+            case string v:
+                w.WriteStringValue(v);
+                break;
+            case Module v:
+                w.WriteModuleValue(v);
+                break;
+            case DateTime v:
+                w.WriteTimeValue(v);
+                break;
+            case DateTimeOffset v:
+                w.WriteTimeValue(v);
+                break;
+            case DateOnly v:
+                w.WriteDateValue(v);
+                break;
+            default:
+                SerializeObjectInternal(w, o, ctx);
+                break;
         }
     }
 
@@ -222,7 +132,7 @@ public static partial class Serializer
         {
             writer.WriteFieldName(field.Name!);
             var v = field.Property.GetValue(obj);
-            SerializeValueInternal(context, writer, v, field.FaunaTypeHint);
+            SerializeValueInternal(context, writer, v);
         }
         if (shouldEscape) writer.WriteEndEscapedObject(); else writer.WriteEndObject();
     }


### PR DESCRIPTION
### Problem
After some deliberation, we decided that supporting a type override attribute is overkill at this point. Types in C# map comfortably to Fauna, so exposing this allows users to do something they probably _shouldn't be doing_, such as modeling an unsigned short and storing it as a long.

### Changes
* Remove FaunaType attribute
* Remove handling of FaunaType attribute in Serializer
* Remove tests specifics to FaunaType overrides
* Add extreme values tests for ushort, uint, and float