### PR TITLE
Use type-driven deserialization for all numbers

### DIFF
--- a/Fauna.Test/Serialization/Deserializer.Tests.cs
+++ b/Fauna.Test/Serialization/Deserializer.Tests.cs
@@ -43,6 +43,15 @@ public class DeserializerTests
         return obj;
     }
 
+    public void RunTestCases<T>(Dictionary<string, T> cases) where T : notnull
+    {
+        foreach (KeyValuePair<string, T> entry in cases)
+        {
+            var result = Deserialize<T>(entry.Key);
+            Assert.AreEqual(entry.Value, result);
+        }
+    }
+
     [Test]
     public void CastDeserializer()
     {
@@ -74,6 +83,110 @@ public class DeserializerTests
             var result = Deserialize(entry.Key);
             Assert.AreEqual(entry.Value, result);
         }
+    }
+
+    [Test]
+    public void DeserializeSByte()
+    {
+        const sbyte val = 42;
+        var tests = new Dictionary<string, sbyte>
+        {
+            {@"{""@int"":""42""}", val},
+        };
+
+        RunTestCases(tests);
+    }
+
+    [Test]
+    public void DeserializeByte()
+    {
+        const byte val = 42;
+        var tests = new Dictionary<string, byte>
+        {
+            {@"{""@int"":""42""}", val},
+        };
+
+        RunTestCases(tests);
+    }
+
+    [Test]
+    public void DeserializeShort()
+    {
+        const short val = 42;
+        var tests = new Dictionary<string, short>
+        {
+            {@"{""@int"":""42""}", val},
+            {@"{""@long"":""42""}", val},
+        };
+
+        RunTestCases(tests);
+    }
+
+    [Test]
+    public void DeserializeUShort()
+    {
+        const ushort val = 42;
+        var tests = new Dictionary<string, ushort>
+        {
+            {@"{""@int"":""42""}", val},
+            {@"{""@long"":""42""}", val},
+        };
+
+        RunTestCases(tests);
+    }
+
+    [Test]
+    public void DeserializeUInt()
+    {
+        const uint val = 42u;
+        var tests = new Dictionary<string, uint>
+        {
+            {@"{""@int"":""42""}", val},
+            {@"{""@long"":""42""}", val},
+        };
+
+        RunTestCases(tests);
+    }
+
+    [Test]
+    public void DeserializeInt()
+    {
+        const int val = 42;
+        var tests = new Dictionary<string, int>
+        {
+            {@"{""@int"":""42""}", val},
+            {@"{""@long"":""42""}", val},
+        };
+
+        RunTestCases(tests);
+    }
+
+    [Test]
+    public void DeserializeFloat()
+    {
+        const float val = 42f;
+        var tests = new Dictionary<string, float>
+        {
+            {@"{""@int"":""42""}", val},
+            {@"{""@long"":""42""}", val},
+            {@"{""@double"": ""42.0""}", val},
+        };
+
+        RunTestCases(tests);
+    }
+
+    [Test]
+    public void DeserializeDouble()
+    {
+        const double val = 42d;
+        var tests = new Dictionary<string, double>
+        {
+            {@"{""@int"":""42""}", val},
+            {@"{""@long"":""42""}", val},
+            {@"{""@double"": ""42.0""}", val},
+        };
+
+        RunTestCases(tests);
     }
 
     [Test]

--- a/Fauna.Test/Serialization/RoundTrip.Tests.cs
+++ b/Fauna.Test/Serialization/RoundTrip.Tests.cs
@@ -1,9 +1,7 @@
 using Fauna.Mapping;
 using Fauna.Serialization;
-using Fauna.Types;
 using NUnit.Framework;
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace Fauna.Test.Serialization;
 
@@ -35,6 +33,24 @@ public class RoundTripTests
     }
 
     [Test]
+    public void RoundTripByte()
+    {
+        const byte test = 3;
+        var serialized = Serialize(test);
+        var deserialized = Deserialize<byte>(serialized);
+        Assert.AreEqual(test, deserialized);
+    }
+
+    [Test]
+    public void RoundTripSByte()
+    {
+        const sbyte test = 3;
+        var serialized = Serialize(test);
+        var deserialized = Deserialize<sbyte>(serialized);
+        Assert.AreEqual(test, deserialized);
+    }
+
+    [Test]
     public void RoundTripShort()
     {
         const short test = 40;
@@ -52,4 +68,48 @@ public class RoundTripTests
         Assert.AreEqual(test, deserialized);
     }
 
+    [Test]
+    public void RoundTripInt()
+    {
+        const int test = 40;
+        var serialized = Serialize(test);
+        var deserialized = Deserialize<short>(serialized);
+        Assert.AreEqual(test, deserialized);
+    }
+
+    [Test]
+    public void RoundTripUInt()
+    {
+        const uint test = 40;
+        var serialized = Serialize(test);
+        var deserialized = Deserialize<uint>(serialized);
+        Assert.AreEqual(test, deserialized);
+    }
+
+    [Test]
+    public void RoundTripLong()
+    {
+        const long test = 40;
+        var serialized = Serialize(test);
+        var deserialized = Deserialize<long>(serialized);
+        Assert.AreEqual(test, deserialized);
+    }
+
+    [Test]
+    public void RoundTripFloat()
+    {
+        const float test = 40.2f;
+        var serialized = Serialize(test);
+        var deserialized = Deserialize<float>(serialized);
+        Assert.AreEqual(test, deserialized);
+    }
+
+    [Test]
+    public void RoundTripDouble()
+    {
+        const double test = 40.2d;
+        var serialized = Serialize(test);
+        var deserialized = Deserialize<double>(serialized);
+        Assert.AreEqual(test, deserialized);
+    }
 }

--- a/Fauna/Serialization/Deserializer.cs
+++ b/Fauna/Serialization/Deserializer.cs
@@ -15,11 +15,15 @@ public static class Deserializer
 
     private static readonly CheckedDeserializer<object> _object = new();
     private static readonly CheckedDeserializer<string> _string = new();
-    private static readonly CheckedDeserializer<int> _int = new();
-    private static readonly LongDeserializer _long = new();
+    private static readonly ByteDeserializer _byte = new();
+    private static readonly SByteDeserializer _sbyte = new();
     private static readonly ShortDeserializer _short = new();
     private static readonly UShortDeserializer _ushort = new();
-    private static readonly CheckedDeserializer<double> _double = new();
+    private static readonly IntDeserializer _int = new();
+    private static readonly UIntDeserializer _uint = new();
+    private static readonly LongDeserializer _long = new();
+    private static readonly FloatDeserializer _float = new();
+    private static readonly DoubleDeserializer _double = new();
     private static readonly CheckedDeserializer<DateOnly> _dateOnly = new();
     private static readonly CheckedDeserializer<DateTime> _dateTime = new();
     private static readonly CheckedDeserializer<bool> _bool = new();
@@ -52,10 +56,14 @@ public static class Deserializer
     {
         if (targetType == typeof(object)) return _object;
         if (targetType == typeof(string)) return _string;
+        if (targetType == typeof(byte)) return _byte;
+        if (targetType == typeof(sbyte)) return _sbyte;
         if (targetType == typeof(short)) return _short;
         if (targetType == typeof(ushort)) return _ushort;
         if (targetType == typeof(int)) return _int;
+        if (targetType == typeof(uint)) return _uint;
         if (targetType == typeof(long)) return _long;
+        if (targetType == typeof(float)) return _float;
         if (targetType == typeof(double)) return _double;
         if (targetType == typeof(DateOnly)) return _dateOnly;
         if (targetType == typeof(DateTime)) return _dateTime;

--- a/Fauna/Serialization/NumberDeserializers.cs
+++ b/Fauna/Serialization/NumberDeserializers.cs
@@ -2,25 +2,36 @@ using Fauna.Mapping;
 
 namespace Fauna.Serialization;
 
-internal class LongDeserializer : BaseDeserializer<long>
+
+internal class ByteDeserializer : BaseDeserializer<byte>
 {
-    public override long Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+    public override byte Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
         reader.CurrentTokenType switch
         {
-            TokenType.Int => reader.GetInt(),
-            TokenType.Long => reader.GetLong(),
+            TokenType.Int => reader.GetByte(),
             _ => throw new SerializationException(
                 $"Unexpected token while deserializing: {reader.CurrentTokenType}"),
         };
 }
+
+internal class SByteDeserializer : BaseDeserializer<sbyte>
+{
+    public override sbyte Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        reader.CurrentTokenType switch
+        {
+            TokenType.Int => reader.GetUnsignedByte(),
+            _ => throw new SerializationException(
+                $"Unexpected token while deserializing: {reader.CurrentTokenType}"),
+        };
+}
+
 
 internal class ShortDeserializer : BaseDeserializer<short>
 {
     public override short Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
         reader.CurrentTokenType switch
         {
-            TokenType.Int => reader.GetShort(),
-            TokenType.Long => reader.GetShort(),
+            TokenType.Int or TokenType.Long => reader.GetShort(),
             _ => throw new SerializationException(
                 $"Unexpected token while deserializing: {reader.CurrentTokenType}"),
         };
@@ -31,8 +42,62 @@ internal class UShortDeserializer : BaseDeserializer<ushort>
     public override ushort Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
         reader.CurrentTokenType switch
         {
-            TokenType.Int => reader.GetUnsignedShort(),
-            TokenType.Long => reader.GetUnsignedShort(),
+            TokenType.Int or TokenType.Long => reader.GetUnsignedShort(),
+            _ => throw new SerializationException(
+                $"Unexpected token while deserializing: {reader.CurrentTokenType}"),
+        };
+}
+
+internal class IntDeserializer : BaseDeserializer<int>
+{
+    public override int Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        reader.CurrentTokenType switch
+        {
+            TokenType.Int or TokenType.Long => reader.GetInt(),
+            _ => throw new SerializationException(
+                $"Unexpected token while deserializing: {reader.CurrentTokenType}"),
+        };
+}
+
+internal class UIntDeserializer : BaseDeserializer<uint>
+{
+    public override uint Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        reader.CurrentTokenType switch
+        {
+            TokenType.Int or TokenType.Long => reader.GetUnsignedInt(),
+            _ => throw new SerializationException(
+                $"Unexpected token while deserializing: {reader.CurrentTokenType}"),
+        };
+}
+
+internal class LongDeserializer : BaseDeserializer<long>
+{
+    public override long Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        reader.CurrentTokenType switch
+        {
+            TokenType.Int or TokenType.Long => reader.GetLong(),
+            _ => throw new SerializationException(
+                $"Unexpected token while deserializing: {reader.CurrentTokenType}"),
+        };
+}
+
+internal class FloatDeserializer : BaseDeserializer<float>
+{
+    public override float Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        reader.CurrentTokenType switch
+        {
+            TokenType.Int or TokenType.Long or TokenType.Double => reader.GetFloat(),
+            _ => throw new SerializationException(
+                $"Unexpected token while deserializing: {reader.CurrentTokenType}"),
+        };
+}
+
+internal class DoubleDeserializer : BaseDeserializer<double>
+{
+    public override double Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        reader.CurrentTokenType switch
+        {
+            TokenType.Int or TokenType.Long or TokenType.Double => reader.GetDouble(),
             _ => throw new SerializationException(
                 $"Unexpected token while deserializing: {reader.CurrentTokenType}"),
         };

--- a/Fauna/Serialization/Utf8FaunaReader.cs
+++ b/Fauna/Serialization/Utf8FaunaReader.cs
@@ -228,12 +228,30 @@ public ref struct Utf8FaunaReader
     }
 
     /// <summary>
+    /// Retrieves a float value from the current token.
+    /// </summary>
+    /// <returns>A float representation of the current token's value.</returns>
+    public float GetFloat()
+    {
+        ValidateTaggedTypes(TokenType.Int, TokenType.Long, TokenType.Double);
+
+        try
+        {
+            return float.Parse(_taggedTokenValue!, CultureInfo.InvariantCulture);
+        }
+        catch (Exception e)
+        {
+            throw new SerializationException($"Failed to get float from {_taggedTokenValue}", e);
+        }
+    }
+
+    /// <summary>
     /// Retrieves a double value from the current token.
     /// </summary>
     /// <returns>A double representation of the current token's value.</returns>
     public double GetDouble()
     {
-        ValidateTaggedType(TokenType.Double);
+        ValidateTaggedTypes(TokenType.Int, TokenType.Long, TokenType.Double);
 
         try
         {
@@ -264,12 +282,48 @@ public ref struct Utf8FaunaReader
     }
 
     /// <summary>
+    /// Retrieves an byte value from the current token.
+    /// </summary>
+    /// <returns>A byte representation of the current token's value.</returns>
+    public byte GetByte()
+    {
+        ValidateTaggedTypes(TokenType.Int);
+
+        try
+        {
+            return byte.Parse(_taggedTokenValue!);
+        }
+        catch (Exception e)
+        {
+            throw new SerializationException($"Failed to get byte from {_taggedTokenValue}", e);
+        }
+    }
+
+    /// <summary>
+    /// Retrieves an unsigned byte value from the current token.
+    /// </summary>
+    /// <returns>An unsigned byte representation of the current token's value.</returns>
+    public sbyte GetUnsignedByte()
+    {
+        ValidateTaggedTypes(TokenType.Int);
+
+        try
+        {
+            return sbyte.Parse(_taggedTokenValue!);
+        }
+        catch (Exception e)
+        {
+            throw new SerializationException($"Failed to get sbyte from {_taggedTokenValue}", e);
+        }
+    }
+
+    /// <summary>
     /// Retrieves an integer value from the current token.
     /// </summary>
     /// <returns>An integer representation of the current token's value.</returns>
     public int GetInt()
     {
-        ValidateTaggedType(TokenType.Int);
+        ValidateTaggedTypes(TokenType.Int, TokenType.Long);
 
         try
         {
@@ -278,6 +332,24 @@ public ref struct Utf8FaunaReader
         catch (Exception e)
         {
             throw new SerializationException($"Failed to get int from {_taggedTokenValue}", e);
+        }
+    }
+
+    /// <summary>
+    /// Retrieves an unsigned integer value from the current token.
+    /// </summary>
+    /// <returns>An unsigned integer representation of the current token's value.</returns>
+    public uint GetUnsignedInt()
+    {
+        ValidateTaggedTypes(TokenType.Int, TokenType.Long);
+
+        try
+        {
+            return uint.Parse(_taggedTokenValue!);
+        }
+        catch (Exception e)
+        {
+            throw new SerializationException($"Failed to get uint from {_taggedTokenValue}", e);
         }
     }
 
@@ -321,7 +393,7 @@ public ref struct Utf8FaunaReader
     /// <returns>A long representation of the current token's value.</returns>
     public long GetLong()
     {
-        ValidateTaggedType(TokenType.Long);
+        ValidateTaggedTypes(TokenType.Int, TokenType.Long);
 
         try
         {


### PR DESCRIPTION
### Problem
Users couldn't roundtrip numbers because we were using the FaunaToken to drive deserialization rather than the target type.

### Change
* Use dedicated deserializers for number types to make numbers roundtrippable.