### PR TITLE
Serialize document types

### DIFF
--- a/Fauna.Test/Serialization/Deserializer.Tests.cs
+++ b/Fauna.Test/Serialization/Deserializer.Tests.cs
@@ -43,7 +43,7 @@ public class DeserializerTests
         return obj;
     }
 
-    public void RunTestCases<T>(Dictionary<string, T> cases) where T : notnull
+    private void RunTestCases<T>(Dictionary<string, T> cases) where T : notnull
     {
         foreach (KeyValuePair<string, T> entry in cases)
         {
@@ -63,7 +63,7 @@ public class DeserializerTests
     }
 
     [Test]
-    public void DeserializeValues()
+    public void DeserializeValuesDynamic()
     {
         var tests = new Dictionary<string, object?>
         {
@@ -243,7 +243,7 @@ public class DeserializerTests
     }
 
     [Test]
-    public void DeserializeDocumentUnchecked()
+    public void DeserializeDocument()
     {
         const string given = @"
                              {
@@ -271,7 +271,7 @@ public class DeserializerTests
     }
 
     [Test]
-    public void DeserializeNullDocumentUnchecked()
+    public void DeserializeNullDocument()
     {
         const string given = @"
                              {
@@ -298,7 +298,7 @@ public class DeserializerTests
     }
 
     [Test]
-    public void DeserializeDocumentChecked()
+    public void DeserializeDocumentGeneric()
     {
         const string given = @"
                              {
@@ -318,7 +318,7 @@ public class DeserializerTests
     }
 
     [Test]
-    public void DeserializeNonNullDocumentChecked()
+    public void DeserializeNonNullDocumentGeneric()
     {
         const string given = @"
                              {
@@ -346,7 +346,7 @@ public class DeserializerTests
     }
 
     [Test]
-    public void DeserializeNullDocumentChecked()
+    public void DeserializeNullDocumentGeneric()
     {
         const string given = @"
                              {
@@ -374,7 +374,7 @@ public class DeserializerTests
     }
 
     [Test]
-    public void DeserializeNullDocumentCheckedThrowsWithoutWrapper()
+    public void DeserializeNullDocumentGenericThrowsWithoutWrapper()
     {
         const string given = @"
                              {

--- a/Fauna.Test/Serialization/RoundTrip.Tests.cs
+++ b/Fauna.Test/Serialization/RoundTrip.Tests.cs
@@ -2,6 +2,7 @@ using Fauna.Mapping;
 using Fauna.Serialization;
 using NUnit.Framework;
 using System.Text;
+using Fauna.Types;
 
 namespace Fauna.Test.Serialization;
 
@@ -9,6 +10,16 @@ namespace Fauna.Test.Serialization;
 public class RoundTripTests
 {
     private static readonly MappingContext ctx = new();
+    private const string IntWire = @"{""@int"":""42""}";
+    private const string LongWire = @"{""@long"":""42""}";
+    private const string DoubleWire = @"{""@double"":""42""}";
+    private const string DoubleWithDecimalWire = @"{""@double"":""42.2""}";
+    private const string DocumentWire = @"{""@doc"":{""id"":""123"",""coll"":{""@mod"":""MyColl""},""ts"":{""@time"":""2023-12-15T01:01:01.0010010Z""},""user_field"":""user_value""}}";
+    private const string DocumentRefWire = @"{""@ref"":{""id"":""123"",""coll"":{""@mod"":""MyColl""}}}";
+    private const string NullDocumentWire = @"{""@ref"":{""id"":""123"",""coll"":{""@mod"":""MyColl""},""exists"":false,""cause"":""not found""}}";
+    private const string NamedDocumentWire = @"{""@doc"":{""name"":""Foo"",""coll"":{""@mod"":""MyColl""},""ts"":{""@time"":""2023-12-15T01:01:01.0010010Z""},""user_field"":""user_value""}}";
+    private const string NullNamedDocumentWire = @"{""@ref"":{""name"":""Foo"",""coll"":{""@mod"":""MyColl""},""exists"":false,""cause"":""not found""}}";
+    private const string NamedDocumentRefWire = @"{""@ref"":{""name"":""Foo"",""coll"":{""@mod"":""MyColl""}}}";
 
     public static string Serialize(object? obj)
     {
@@ -35,81 +46,177 @@ public class RoundTripTests
     [Test]
     public void RoundTripByte()
     {
-        const byte test = 3;
-        var serialized = Serialize(test);
-        var deserialized = Deserialize<byte>(serialized);
-        Assert.AreEqual(test, deserialized);
+        var deserialized = Deserialize<byte>(IntWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(IntWire, serialized);
     }
 
     [Test]
     public void RoundTripSByte()
     {
-        const sbyte test = 3;
-        var serialized = Serialize(test);
-        var deserialized = Deserialize<sbyte>(serialized);
-        Assert.AreEqual(test, deserialized);
+        var deserialized = Deserialize<sbyte>(IntWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(IntWire, serialized);
     }
 
     [Test]
     public void RoundTripShort()
     {
-        const short test = 40;
-        var serialized = Serialize(test);
-        var deserialized = Deserialize<short>(serialized);
-        Assert.AreEqual(test, deserialized);
+        var deserialized = Deserialize<short>(IntWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(IntWire, serialized);
     }
 
     [Test]
     public void RoundTripUShort()
     {
-        const ushort test = 40;
-        var serialized = Serialize(test);
-        var deserialized = Deserialize<ushort>(serialized);
-        Assert.AreEqual(test, deserialized);
+        var deserialized = Deserialize<ushort>(IntWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(IntWire, serialized);
     }
 
     [Test]
     public void RoundTripInt()
     {
-        const int test = 40;
-        var serialized = Serialize(test);
-        var deserialized = Deserialize<short>(serialized);
-        Assert.AreEqual(test, deserialized);
+        var deserialized = Deserialize<int>(IntWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(IntWire, serialized);
     }
 
     [Test]
     public void RoundTripUInt()
     {
-        const uint test = 40;
-        var serialized = Serialize(test);
-        var deserialized = Deserialize<uint>(serialized);
-        Assert.AreEqual(test, deserialized);
+        var deserialized = Deserialize<uint>(LongWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(LongWire, serialized);
     }
 
     [Test]
     public void RoundTripLong()
     {
-        const long test = 40;
-        var serialized = Serialize(test);
-        var deserialized = Deserialize<long>(serialized);
-        Assert.AreEqual(test, deserialized);
+        var deserialized = Deserialize<long>(LongWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(LongWire, serialized);
     }
 
     [Test]
     public void RoundTripFloat()
     {
-        const float test = 40.2f;
-        var serialized = Serialize(test);
-        var deserialized = Deserialize<float>(serialized);
-        Assert.AreEqual(test, deserialized);
+        var deserialized = Deserialize<float>(DoubleWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(DoubleWire, serialized);
     }
 
     [Test]
     public void RoundTripDouble()
     {
-        const double test = 40.2d;
-        var serialized = Serialize(test);
-        var deserialized = Deserialize<double>(serialized);
-        Assert.AreEqual(test, deserialized);
+        var deserialized = Deserialize<double>(DoubleWithDecimalWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(DoubleWithDecimalWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripClassAsDocumentIsNotSupported()
+    {
+        var deserialized = Deserialize<ClassForDocument>(DocumentWire);
+        var serialized = Serialize(deserialized);
+        var expected = @"{""id"":{""@long"":""123""},""user_field"":""user_value""}";
+        Assert.AreEqual(expected, serialized);
+    }
+
+    [Test]
+    public void RoundTripDocumentRef()
+    {
+        var deserialized = Deserialize<DocumentRef>(DocumentRefWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(DocumentRefWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripNonNullDocumentRef()
+    {
+        var deserialized = Deserialize<NullableDocument<DocumentRef>>(DocumentRefWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(DocumentRefWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripNullDocumentRefChangesToDocumentRef()
+    {
+        var deserialized = Deserialize<NullableDocument<DocumentRef>>(NullDocumentWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(DocumentRefWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripDocumentChangesToDocumentReference()
+    {
+        var deserialized = Deserialize<Document>(DocumentWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(DocumentRefWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripNonNullDocumentChangesToDocumentReference()
+    {
+        var deserialized = Deserialize<NullableDocument<Document>>(DocumentWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(DocumentRefWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripNullDocumentChangesToDocumentReference()
+    {
+        var deserialized = Deserialize<NullableDocument<Document>>(NullDocumentWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(DocumentRefWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripNamedDocumentRef()
+    {
+        var deserialized = Deserialize<NamedDocumentRef>(NamedDocumentRefWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(NamedDocumentRefWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripNonNullNamedDocumentRef()
+    {
+        var deserialized = Deserialize<NullableDocument<NamedDocumentRef>>(NamedDocumentRefWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(NamedDocumentRefWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripNullNamedDocumentRefChangesToNamedDocumentRef()
+    {
+        var deserialized = Deserialize<NullableDocument<NamedDocumentRef>>(NullNamedDocumentWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(NamedDocumentRefWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripNamedDocumentChangesToNamedDocumentReference()
+    {
+        var deserialized = Deserialize<NamedDocument>(NamedDocumentWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(NamedDocumentRefWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripNonNullNamedDocumentChangesToNamedDocumentReference()
+    {
+        var deserialized = Deserialize<NullableDocument<NamedDocument>>(NamedDocumentWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(NamedDocumentRefWire, serialized);
+    }
+
+    [Test]
+    public void RoundTripNullNamedDocumentChangesToNamedDocumentReference()
+    {
+        var deserialized = Deserialize<NullableDocument<NamedDocument>>(NullNamedDocumentWire);
+        var serialized = Serialize(deserialized);
+        Assert.AreEqual(NamedDocumentRefWire, serialized);
     }
 }

--- a/Fauna.Test/Serialization/Serializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializer.Tests.cs
@@ -3,7 +3,6 @@ using Fauna.Serialization;
 using Fauna.Types;
 using NUnit.Framework;
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace Fauna.Test.Serialization;
 
@@ -47,6 +46,8 @@ public class SerializerTests
             // \u002 is the + character. This is expected because we do not
             // enable unsafe json serialization. Fauna wire protocol supports this.
             {@"{""@time"":""2023-12-14T12:12:12.0010010\u002B00:00""}", new DateTimeOffset(dt.AddDays(1))},
+            {@"{""@ref"":{""id"":""123"",""coll"":{""@mod"":""ACollection""}}}", new DocumentRef("123", new Module("ACollection"))},
+            {@"{""@ref"":{""id"":""124"",""coll"":{""@mod"":""ACollection""}}}", new Document("124", new Module("ACollection"), DateTime.Now)}
         };
 
         foreach (var (expected, test) in tests)
@@ -194,7 +195,7 @@ public class SerializerTests
     }
 
     [Test]
-    public void SerializeCollectionEdgeCases()
+    public void SerializeEmptyCollections()
     {
         var tests = new Dictionary<object, string>
         {

--- a/Fauna.Test/Serialization/TestClasses.cs
+++ b/Fauna.Test/Serialization/TestClasses.cs
@@ -1,4 +1,5 @@
 using Fauna.Mapping.Attributes;
+using Fauna.Types;
 
 namespace Fauna.Test.Serialization;
 


### PR DESCRIPTION
### Problem
We didn't handle serialization of documents and named documents.

### Changes
* Add serialization support for
  * Document, DocumentRef, NamedDocument, NamedDocumentRef
  * NullableDocument<> for each of the above
* Fix roundtrip test ordering
* Add roundtrip tests that show that we don't roundtrip classes as documents