### PR TITLE
Add Function support to LINQ DSL

### DIFF
--- a/Fauna.Test/Helpers/Fixtures.cs
+++ b/Fauna.Test/Helpers/Fixtures.cs
@@ -19,6 +19,12 @@ public class AuthorDb : DataContext
     }
 
     public AuthorCol Author { get => GetCollection<AuthorCol>(); }
+
+    public Function<int> Add2(int val) => Fn<int>().Call(val);
+    public Function<string> SayHello() => Fn<string>("SayHello").Call();
+    public Function<string> SayHelloArray() => Fn<string>("SayHelloArray").Call();
+    public Function<Author> GetAuthors() => Fn<Author>().Call();
+
 }
 
 public class EmbeddedSet
@@ -40,6 +46,11 @@ public static class Fixtures
     public static AuthorDb AuthorDb(Client client)
     {
         client.QueryAsync(FQL($"Collection.byName('Author')?.delete()")).Wait();
+        client.QueryAsync(FQL($"Function.byName('SayHello')?.delete()")).Wait();
+        client.QueryAsync(FQL($"Function.byName('SayHelloArray')?.delete()")).Wait();
+        client.QueryAsync(FQL($"Function.byName('GetAuthors')?.delete()")).Wait();
+        client.QueryAsync(FQL($"Function.byName('Add2')?.delete()")).Wait();
+
         client.QueryAsync(FQL(
             $@"Collection.create({{
                 name: 'Author',
@@ -52,7 +63,10 @@ public static class Fixtures
             .Wait();
         client.QueryAsync(FQL($"Author.create({{name: 'Alice', age: 32 }})")).Wait();
         client.QueryAsync(FQL($"Author.create({{name: 'Bob', age: 26 }})")).Wait();
-
+        client.QueryAsync(FQL($"Function.create({{name: 'SayHello', body: '() => \"Hello!\"'}})")).Wait();
+        client.QueryAsync(FQL($"Function.create({{name: 'SayHelloArray', body: '() => [SayHello(), SayHello()]'}})")).Wait();
+        client.QueryAsync(FQL($"Function.create({{name: 'GetAuthors', body: '() => Author.all()'}})")).Wait();
+        client.QueryAsync(FQL($"Function.create({{name: 'Add2', body: '(t) => t + 2'}})")).Wait();
         return client.DataContext<AuthorDb>();
     }
 

--- a/Fauna.Test/Linq/Context.Tests.cs
+++ b/Fauna.Test/Linq/Context.Tests.cs
@@ -32,8 +32,11 @@ public class ContextTests
         [Name("posts")]
         public class PostCol : Collection<Post> { }
 
-        public AuthorCol Author { get => GetCollection<AuthorCol>(); }
-        public PostCol Post { get => GetCollection<PostCol>(); }
+        public AuthorCol Author => GetCollection<AuthorCol>();
+        public PostCol Post => GetCollection<PostCol>();
+        public Function<string> TestFunc() => Fn<string>("TestFunc").Call();
+        public Function<string> TestFuncInferred() => Fn<string>().Call();
+
     }
 
     [AllowNull]
@@ -70,5 +73,15 @@ public class ContextTests
         Assert.AreEqual(byName2.Name, "realByName");
         Assert.AreEqual(byName2.DocType, typeof(Author));
         Assert.AreEqual(byName2.Args, new object[] { "Alice" });
+
+        var fn = db.TestFunc();
+        Assert.AreEqual(fn.Name, "TestFunc");
+        Assert.AreEqual(fn.ReturnType, typeof(string));
+        Assert.AreEqual(fn.Args, Array.Empty<object>());
+
+        var fnInferred = db.TestFuncInferred();
+        Assert.AreEqual(fnInferred.Name, "TestFuncInferred");
+        Assert.AreEqual(fnInferred.ReturnType, typeof(string));
+        Assert.AreEqual(fnInferred.Args, Array.Empty<object>());
     }
 }

--- a/Fauna.Test/Linq/Query.Tests.cs
+++ b/Fauna.Test/Linq/Query.Tests.cs
@@ -558,10 +558,17 @@ public class QueryTests
     }
 
     [Test]
-    public async Task Query_Function_Single()
+    public async Task Query_Function_Value_Single()
     {
         var ret = await db.SayHello().SingleAsync();
         Assert.AreEqual("Hello!", ret);
+    }
+
+    [Test]
+    public async Task Query_Function_Value_List()
+    {
+        var ret = await db.SayHello().ToListAsync();
+        Assert.AreEqual(new List<string> { "Hello!" }, ret);
     }
 
     [Test]

--- a/Fauna.Test/Linq/Query.Tests.cs
+++ b/Fauna.Test/Linq/Query.Tests.cs
@@ -556,4 +556,32 @@ public class QueryTests
         var names = authors.Select(a => a.Name);
         Assert.AreEqual(new List<string> { "Alice" }, names);
     }
+
+    [Test]
+    public async Task Query_Function_Single()
+    {
+        var ret = await db.SayHello().SingleAsync();
+        Assert.AreEqual("Hello!", ret);
+    }
+
+    [Test]
+    public async Task Query_Function_With_Param()
+    {
+        var ret = await db.Add2(8).SingleAsync();
+        Assert.AreEqual(10, ret);
+    }
+
+    [Test]
+    public async Task Query_Function_Array()
+    {
+        var ret = await db.SayHelloArray().ToListAsync();
+        Assert.AreEqual(new List<string> { "Hello!", "Hello!" }, ret);
+    }
+
+    [Test]
+    public async Task Query_Function_Set()
+    {
+        var ret = await db.GetAuthors().Select(x => x.Name).ToListAsync();
+        Assert.AreEqual(new List<string> { "Alice", "Bob" }, ret);
+    }
 }

--- a/Fauna.Test/Serialization/Deserializer.Tests.cs
+++ b/Fauna.Test/Serialization/Deserializer.Tests.cs
@@ -982,6 +982,15 @@ public class DeserializerTests
     }
 
     [Test]
+    public void DeserializeIntoListFromSingleValue()
+    {
+        const string given = @"""item1""";
+        var expected = new List<string> { "item1" };
+        var p = Deserialize<List<string>>(given);
+        Assert.AreEqual(expected, p);
+    }
+
+    [Test]
     public void DeserializeIntoGenericListWithPrimitive()
     {
         const string given = @"[""item1"",""item2""]";
@@ -1027,6 +1036,17 @@ public class DeserializerTests
         Assert.IsNotNull(result);
         Assert.AreEqual(new List<int> { 1, 2, 3 }, result.Data);
         Assert.AreEqual("next_page_cursor", result.After);
+    }
+
+    [Test]
+    public void DeserializeIntoPageWithSingleValue()
+    {
+        const string given = @"""SingleValue""";
+
+        var result = Deserialize<Page<string>>(given);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(new List<string> { "SingleValue" }, result.Data);
+        Assert.IsNull(result.After);
     }
 
     [Test]

--- a/Fauna/Linq/DataContextBuilder.cs
+++ b/Fauna/Linq/DataContextBuilder.cs
@@ -38,7 +38,7 @@ internal class DataContextBuilder<DB> where DB : DataContext
     }
 
     private static bool IsColType(Type ty) =>
-        ty.GetInterfaces().Where(iface => iface == typeof(DataContext.Collection)).Any();
+        ty.GetInterfaces().Any(iface => iface == typeof(DataContext.Collection));
 
     private static void ValidateColType(Type ty)
     {

--- a/Fauna/Linq/IntermediateQueryHelpers.cs
+++ b/Fauna/Linq/IntermediateQueryHelpers.cs
@@ -70,6 +70,9 @@ internal static class IntermediateQueryHelpers
     public static Query CollectionIndex(DataContext.Index idx) =>
         MethodCall(Expr(idx.Collection.Name), idx.Name, idx.Args.Select(Const));
 
+    public static Query Function(DataContext.IFunction fnc) =>
+        FnCall(fnc.Name, fnc.Args.Select(Const));
+
     public static QueryExpr Concat(this Query q1, string str)
     {
         var frags = new List<IQueryFragment>();

--- a/Fauna/Linq/QuerySourceDsl.cs
+++ b/Fauna/Linq/QuerySourceDsl.cs
@@ -324,9 +324,14 @@ public partial class QuerySource<T>
 
     private Query Singularize(Query setq) =>
         QH.Expr(@"({
-          let s = (").Concat(setq).Concat(@").take(2).toArray()
-          if (s.length > 1) abort(['not single'])
-          s.take(1)
+          let s = (").Concat(setq).Concat(@")
+          let s = if (s isa Set) s.toArray() else s
+          if (s isa Array) {
+            if (s.length > 1) abort(['not single'])
+            s.take(1)
+          } else {
+            [s]
+          }
         })");
 
     private Exception TranslateException(Exception ex) =>

--- a/Fauna/Linq/SubQuerySwitch.cs
+++ b/Fauna/Linq/SubQuerySwitch.cs
@@ -19,18 +19,12 @@ internal class SubQuerySwitch : DefaultExpressionSwitch<Query>
 
     protected override Query ConstantExpr(ConstantExpression expr)
     {
-        if (expr.Value is DataContext.Collection col)
+        return expr.Value switch
         {
-            return QH.CollectionAll(col);
-        }
-        else if (expr.Value is DataContext.Index idx)
-        {
-            return QH.CollectionIndex(idx);
-        }
-        else
-        {
-            return QH.Const(expr.Value);
-        }
+            DataContext.Collection col => QH.CollectionAll(col),
+            DataContext.Index idx => QH.CollectionIndex(idx),
+            _ => QH.Const(expr.Value)
+        };
     }
 
     protected override Query LambdaExpr(LambdaExpression expr)

--- a/Fauna/Serialization/ListDeserializer.cs
+++ b/Fauna/Serialization/ListDeserializer.cs
@@ -13,14 +13,24 @@ internal class ListDeserializer<T> : BaseDeserializer<List<T>>
 
     public override List<T> Deserialize(MappingContext context, ref Utf8FaunaReader reader)
     {
-        if (reader.CurrentTokenType != TokenType.StartArray)
+        if (reader.CurrentTokenType == TokenType.StartPage)
             throw new SerializationException(
-                $"Unexpected token while deserializing into {typeof(List<T>)}: {reader.CurrentTokenType}");
+            $"Unexpected token while deserializing into {typeof(List<T>)}: {reader.CurrentTokenType}");
+
+        var wrapInList = reader.CurrentTokenType != TokenType.StartArray;
 
         var lst = new List<T>();
-        while (reader.Read() && reader.CurrentTokenType != TokenType.EndArray)
+
+        if (wrapInList)
         {
             lst.Add(_elemDeserializer.Deserialize(context, ref reader));
+        }
+        else
+        {
+            while (reader.Read() && reader.CurrentTokenType != TokenType.EndArray)
+            {
+                lst.Add(_elemDeserializer.Deserialize(context, ref reader));
+            }
         }
 
         return lst;

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ class PersonDb : DataContext
     }
 
     public PersonCollection Person { get => GetCollection<PersonCollection>(); }
+    public Function<int> AddTwo(int val) => Fn<int>().Call(val);
+    public Function<int> TimesTwo(int val) => Fn<int>("MultiplyByTwo").Call(val);
 }
 ```
 


### PR DESCRIPTION
### Problem
We want to expose support for calling User-Defined Functions via LINQ.

### Solution
Collections and Indexes return sets whereas Functions can return anything. We could approach this a few ways, but I chose to make the existing QuerySource implementation work for functions. As such, the type declarations for functions are a little counter intuitive. Developers must type the Function based on the _element_ type it returns. For example, if it returns a single value, `T` in `Function<T>` must be that type. If it returns an array or set, the `T` must be the type of the element in the array or set.

E.g. 1: If a function returns a string, the type definition must be `Function<string>`. The caller may call `.Single()` to get a single value back, or `.ToList()` to get a list with a single element. 

E.g. 2: If a function returns an array or set of strings, the type definition must still be singular, such as `Function<string>`, similar to how one declares a `Collection<T>` or `Index<T>`.

### Changes
* Add DSL for Functions
* Add array support to Page deserializer for cases when an array is returned and the DSL assumes we're interacting with a Page.
* Add single value support to the Page and List deserializers for cases when a function returns a single value but, for example, the user wants to use the LINQ API to get a List.
* Handle objects/primitives and arrays (in addition to sets) in Single/SingleAsync.
* Accept a few misc IDE recommendations