### PR TITLE
Invoke function calls directly

### DIFF
--- a/Fauna.Test/Helpers/Fixtures.cs
+++ b/Fauna.Test/Helpers/Fixtures.cs
@@ -1,4 +1,5 @@
 using Fauna.Mapping.Attributes;
+using Fauna.Types;
 using static Fauna.Query;
 
 namespace Fauna.Test;
@@ -22,10 +23,10 @@ public class AuthorDb : DataContext
 
     public AuthorCol Author { get => GetCollection<AuthorCol>(); }
 
-    public Function<int> Add2(int val) => Fn<int>().Call(val);
-    public Function<string> SayHello() => Fn<string>("SayHello").Call();
-    public Function<string> SayHelloArray() => Fn<string>("SayHelloArray").Call();
-    public Function<Author> GetAuthors() => Fn<Author>().Call();
+    public async Task<int> Add2(int val) => await Fn<int>().CallAsync(val);
+    public string SayHello() => Fn<string>("SayHello").Call();
+    public List<string> SayHelloArray() => Fn<List<string>>("SayHelloArray").Call();
+    public async Task<Page<Author>> GetAuthors() => await Fn<Page<Author>>().CallAsync();
 
 }
 

--- a/Fauna.Test/Linq/Context.Tests.cs
+++ b/Fauna.Test/Linq/Context.Tests.cs
@@ -34,8 +34,8 @@ public class ContextTests
 
         public AuthorCol Author => GetCollection<AuthorCol>();
         public PostCol Post => GetCollection<PostCol>();
-        public Function<string> TestFunc() => Fn<string>("TestFunc").Call();
-        public Function<string> TestFuncInferred() => Fn<string>().Call();
+        public string TestFunc() => Fn<string>("TestFunc").Call();
+        public string TestFuncInferred() => Fn<string>().Call();
 
     }
 
@@ -73,15 +73,5 @@ public class ContextTests
         Assert.AreEqual(byName2.Name, "realByName");
         Assert.AreEqual(byName2.DocType, typeof(Author));
         Assert.AreEqual(byName2.Args, new object[] { "Alice" });
-
-        var fn = db.TestFunc();
-        Assert.AreEqual(fn.Name, "TestFunc");
-        Assert.AreEqual(fn.ReturnType, typeof(string));
-        Assert.AreEqual(fn.Args, Array.Empty<object>());
-
-        var fnInferred = db.TestFuncInferred();
-        Assert.AreEqual(fnInferred.Name, "TestFuncInferred");
-        Assert.AreEqual(fnInferred.ReturnType, typeof(string));
-        Assert.AreEqual(fnInferred.Args, Array.Empty<object>());
     }
 }

--- a/Fauna.Test/Linq/Query.Tests.cs
+++ b/Fauna.Test/Linq/Query.Tests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System.Diagnostics.CodeAnalysis;
+using Telerik.JustMock.Helpers;
 using static Fauna.Test.Helpers.TestClientHelper;
 
 namespace Fauna.Test.Linq;
@@ -581,45 +582,38 @@ public class QueryTests
     }
 
     [Test]
-    public async Task Query_Function_Value_Single()
+    public void Query_Function_Value_Single()
     {
-        var ret = await _db.SayHello().SingleAsync();
+        var ret = _db.SayHello();
         Assert.AreEqual("Hello!", ret);
-    }
-
-    [Test]
-    public async Task Query_Function_Value_List()
-    {
-        var ret = await _db.SayHello().ToListAsync();
-        Assert.AreEqual(new List<string> { "Hello!" }, ret);
     }
 
     [Test]
     public async Task Query_Function_With_Param()
     {
-        var ret = await _db.Add2(8).SingleAsync();
+        var ret = await _db.Add2(8);
         Assert.AreEqual(10, ret);
     }
 
     [Test]
-    public async Task Query_Function_Array()
+    public void Query_Function_Array()
     {
-        var ret = await _db.SayHelloArray().ToListAsync();
+        var ret = _db.SayHelloArray();
         Assert.AreEqual(new List<string> { "Hello!", "Hello!" }, ret);
     }
 
     [Test]
     public async Task Query_Function_Set()
     {
-        var ret = await _db.GetAuthors().Select(x => x.Name).ToListAsync();
-        Assert.AreEqual(new List<string> { "Alice", "Bob" }, ret);
+        var ret = await _db.GetAuthors();
+        Assert.AreEqual(new List<string> { "Alice", "Bob" }, ret.Data.Select(a => a.Name));
     }
 
     [Test]
     public async Task Query_CastTypes()
     {
-        Assert.AreEqual(new[] { 91, 83 }, await _db.GetAuthors().Select(a => (int)a.Score).ToArrayAsync());
-        Assert.AreEqual(new[] { 32.0D, 26.0D }, await _db.GetAuthors().Select(a => (double)a.Age).ToArrayAsync());
-        Assert.AreEqual(new[] { 91L, 83L }, await _db.GetAuthors().Select(a => (long)a.Score).ToArrayAsync());
+        Assert.AreEqual(new[] { 91, 83 }, await _db.Author.Select(a => (int)a.Score).ToArrayAsync());
+        Assert.AreEqual(new[] { 32.0D, 26.0D }, await _db.Author.Select(a => (double)a.Age).ToArrayAsync());
+        Assert.AreEqual(new[] { 91L, 83L }, await _db.Author.Select(a => (long)a.Score).ToArrayAsync());
     }
 }

--- a/Fauna/Linq/IntermediateQueryHelpers.cs
+++ b/Fauna/Linq/IntermediateQueryHelpers.cs
@@ -69,8 +69,8 @@ internal static class IntermediateQueryHelpers
     public static Query CollectionIndex(DataContext.IIndex idx) =>
         MethodCall(Expr(idx.Collection.Name), idx.Name, idx.Args.Select(Const));
 
-    public static Query Function(DataContext.IFunction fnc) =>
-        FnCall(fnc.Name, fnc.Args.Select(Const));
+    public static Query Function(string name, object[] args) =>
+        FnCall(name, args.Select(Const));
 
     public static QueryExpr Concat(this Query q1, string str)
     {

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ class PersonDb : DataContext
     }
 
     public PersonCollection Person { get => GetCollection<PersonCollection>(); }
-    public Function<int> AddTwo(int val) => Fn<int>().Call(val);
-    public Function<int> TimesTwo(int val) => Fn<int>("MultiplyByTwo").Call(val);
+    public int AddTwo(int val) => Fn<int>().Call(val);
+    public async Task<int> TimesTwo(int val) => await Fn<int>("MultiplyByTwo").CallAsync(val);
 }
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Modify Function DSL such that invocations return the type directly instead of a QuerySource

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
We want a more natural API for function calls when using the DataContext. Users can now clearly declare the return type of a function instead of mixing in LINQ semantics that offer minimal benefit to function invocations.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Unit tests updated.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to Fauna documentation.
- [X] My change requires a change to the README, and I have updated it accordingly.
