### PR TITLE
Use generated serializers for QueryVal serialization

### DIFF
--- a/Fauna.Test/Serialization/RoundTrip.Tests.cs
+++ b/Fauna.Test/Serialization/RoundTrip.Tests.cs
@@ -31,7 +31,11 @@ public class RoundTripTests
     {
         using var stream = new MemoryStream();
         using var writer = new Utf8FaunaWriter(stream);
-        DynamicSerializer.Singleton.Serialize(ctx, writer, obj);
+
+        ISerializer ser = DynamicSerializer.Singleton;
+        if (obj is not null) ser = Serializer.Generate(ctx, obj.GetType());
+        ser.Serialize(ctx, writer, obj);
+
         writer.Flush();
         return Encoding.UTF8.GetString(stream.ToArray());
     }

--- a/Fauna.Test/Serialization/Serializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializer.Tests.cs
@@ -15,7 +15,11 @@ public class SerializerTests
     {
         using var stream = new MemoryStream();
         using var writer = new Utf8FaunaWriter(stream);
-        DynamicSerializer.Singleton.Serialize(ctx, writer, obj);
+
+        ISerializer ser = DynamicSerializer.Singleton;
+        if (obj is not null) ser = Serializer.Generate(ctx, obj.GetType());
+        ser.Serialize(ctx, writer, obj);
+
         writer.Flush();
         return Encoding.UTF8.GetString(stream.ToArray());
     }

--- a/Fauna/Query/QueryVal.cs
+++ b/Fauna/Query/QueryVal.cs
@@ -19,6 +19,7 @@ public sealed class QueryVal : Query, IQueryFragment
     /// <param name="v">The value of the specified type to be represented in the query.</param>
     public QueryVal(object? v)
     {
+
         Unwrap = v;
     }
 
@@ -31,7 +32,8 @@ public sealed class QueryVal : Query, IQueryFragment
     {
         writer.WriteStartObject();
         writer.WriteFieldName("value");
-        DynamicSerializer.Singleton.Serialize(ctx, writer, Unwrap);
+        var ser = Unwrap is not null ? Serializer.Generate(ctx, Unwrap.GetType()) : DynamicSerializer.Singleton;
+        ser.Serialize(ctx, writer, Unwrap);
         writer.WriteEndObject();
     }
 

--- a/Fauna/Serialization/ISerializer.cs
+++ b/Fauna/Serialization/ISerializer.cs
@@ -15,6 +15,10 @@ public interface ISerializer
 
 public abstract class BaseSerializer<T> : ISerializer<T>
 {
+    protected string UnexpectedTokenExceptionMessage(TokenType token) => $"Unexpected token `{token}` deserializing with `{GetType()}`";
+
+    protected string UnsupportedSerializationTypeMessage(Type type) => $"Cannot serialize `{type}` with `{GetType()}`";
+
     object? ISerializer.Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
         Deserialize(context, ref reader);
 

--- a/Fauna/Serialization/Serializers/CheckedSerializer.cs
+++ b/Fauna/Serialization/Serializers/CheckedSerializer.cs
@@ -16,6 +16,6 @@ internal class CheckedSerializer<T> : BaseSerializer<T>
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        DynamicSerializer.Singleton.Serialize(context, writer, o);
     }
 }

--- a/Fauna/Serialization/Serializers/ClassSerializer.cs
+++ b/Fauna/Serialization/Serializers/ClassSerializer.cs
@@ -93,7 +93,7 @@ internal class ClassSerializer<T> : BaseSerializer<T>, IClassSerializer
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        DynamicSerializer.Singleton.Serialize(context, writer, o);
     }
 
     private object CreateInstance() => Activator.CreateInstance(_info.Type)!;

--- a/Fauna/Serialization/Serializers/DictionarySerializer.cs
+++ b/Fauna/Serialization/Serializers/DictionarySerializer.cs
@@ -35,6 +35,6 @@ internal class DictionarySerializer<T> : BaseSerializer<Dictionary<string, T>>
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        DynamicSerializer.Singleton.Serialize(context, writer, o);
     }
 }

--- a/Fauna/Serialization/Serializers/DocumentSerializer.cs
+++ b/Fauna/Serialization/Serializers/DocumentSerializer.cs
@@ -20,7 +20,7 @@ internal class DocumentSerializer<T> : BaseSerializer<T> where T : class
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        DynamicSerializer.Singleton.Serialize(context, writer, o);
     }
 
     private T DeserializeDocument(MappingContext context, ref Utf8FaunaReader reader)

--- a/Fauna/Serialization/Serializers/ListSerializer.cs
+++ b/Fauna/Serialization/Serializers/ListSerializer.cs
@@ -38,6 +38,6 @@ internal class ListSerializer<T> : BaseSerializer<List<T>>
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        DynamicSerializer.Singleton.Serialize(context, writer, o);
     }
 }

--- a/Fauna/Serialization/Serializers/ModuleSerializer.cs
+++ b/Fauna/Serialization/Serializers/ModuleSerializer.cs
@@ -15,6 +15,6 @@ internal class ModuleSerializer : BaseSerializer<Module>
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        DynamicSerializer.Singleton.Serialize(context, writer, o);
     }
 }

--- a/Fauna/Serialization/Serializers/NullableDocumentSerializer.cs
+++ b/Fauna/Serialization/Serializers/NullableDocumentSerializer.cs
@@ -40,6 +40,6 @@ internal class NullableDocumentSerializer<T> : BaseSerializer<NullableDocument<T
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        DynamicSerializer.Singleton.Serialize(context, writer, o);
     }
 }

--- a/Fauna/Serialization/Serializers/NullableSerializer.cs
+++ b/Fauna/Serialization/Serializers/NullableSerializer.cs
@@ -23,6 +23,6 @@ internal class NullableSerializer<T> : BaseSerializer<T?>
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        DynamicSerializer.Singleton.Serialize(context, writer, o);
     }
 }

--- a/Fauna/Serialization/Serializers/NullableStructSerializer.cs
+++ b/Fauna/Serialization/Serializers/NullableStructSerializer.cs
@@ -23,6 +23,6 @@ internal class NullableStructSerializer<T> : BaseSerializer<T?> where T : struct
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        DynamicSerializer.Singleton.Serialize(context, writer, o);
     }
 }

--- a/Fauna/Serialization/Serializers/PageSerializer.cs
+++ b/Fauna/Serialization/Serializers/PageSerializer.cs
@@ -63,6 +63,6 @@ internal class PageSerializer<T> : BaseSerializer<Page<T>>
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        DynamicSerializer.Singleton.Serialize(context, writer, o);
     }
 }

--- a/Fauna/Serialization/Serializers/StructSerializers.cs
+++ b/Fauna/Serialization/Serializers/StructSerializers.cs
@@ -10,12 +10,22 @@ internal class StringSerializer : BaseSerializer<string?>
         reader.CurrentTokenType switch
         {
             TokenType.String => reader.GetString(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case string s:
+                writer.WriteStringValue(s);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -25,12 +35,22 @@ internal class ByteSerializer : BaseSerializer<byte>
         reader.CurrentTokenType switch
         {
             TokenType.Int => reader.GetByte(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case byte i:
+                writer.WriteIntValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -40,12 +60,22 @@ internal class SByteSerializer : BaseSerializer<sbyte>
         reader.CurrentTokenType switch
         {
             TokenType.Int => reader.GetUnsignedByte(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case sbyte i:
+                writer.WriteIntValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -56,12 +86,22 @@ internal class ShortSerializer : BaseSerializer<short>
         reader.CurrentTokenType switch
         {
             TokenType.Int or TokenType.Long => reader.GetShort(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case short i:
+                writer.WriteIntValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -71,12 +111,22 @@ internal class UShortSerializer : BaseSerializer<ushort>
         reader.CurrentTokenType switch
         {
             TokenType.Int or TokenType.Long => reader.GetUnsignedShort(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case ushort i:
+                writer.WriteIntValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -86,12 +136,22 @@ internal class IntSerializer : BaseSerializer<int>
         reader.CurrentTokenType switch
         {
             TokenType.Int or TokenType.Long => reader.GetInt(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case int i:
+                writer.WriteIntValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -101,12 +161,22 @@ internal class UIntSerializer : BaseSerializer<uint>
         reader.CurrentTokenType switch
         {
             TokenType.Int or TokenType.Long => reader.GetUnsignedInt(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case uint i:
+                writer.WriteLongValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -116,12 +186,22 @@ internal class LongSerializer : BaseSerializer<long>
         reader.CurrentTokenType switch
         {
             TokenType.Int or TokenType.Long => reader.GetLong(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case long i:
+                writer.WriteLongValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -131,12 +211,22 @@ internal class FloatSerializer : BaseSerializer<float>
         reader.CurrentTokenType switch
         {
             TokenType.Int or TokenType.Long or TokenType.Double => reader.GetFloat(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case float i:
+                writer.WriteDoubleValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -146,12 +236,22 @@ internal class DoubleSerializer : BaseSerializer<double>
         reader.CurrentTokenType switch
         {
             TokenType.Int or TokenType.Long or TokenType.Double => reader.GetDouble(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case double i:
+                writer.WriteDoubleValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -161,12 +261,22 @@ internal class BooleanSerializer : BaseSerializer<bool>
         reader.CurrentTokenType switch
         {
             TokenType.True or TokenType.False => reader.GetBoolean(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case bool i:
+                writer.WriteBooleanValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -176,12 +286,22 @@ internal class DateOnlySerializer : BaseSerializer<DateOnly>
         reader.CurrentTokenType switch
         {
             TokenType.Date => reader.GetDate(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case DateOnly i:
+                writer.WriteDateValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }
 
@@ -191,11 +311,46 @@ internal class DateTimeSerializer : BaseSerializer<DateTime>
         reader.CurrentTokenType switch
         {
             TokenType.Time => reader.GetTime(),
-            _ => throw UnexpectedToken(reader.CurrentTokenType)
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        throw new NotImplementedException();
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case DateTime i:
+                writer.WriteTimeValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
+    }
+}
+
+internal class DateTimeOffsetSerializer : BaseSerializer<DateTimeOffset>
+{
+    public override DateTimeOffset Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        reader.CurrentTokenType switch
+        {
+            TokenType.Time => reader.GetTime(),
+            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+        };
+
+    public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
+    {
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case DateTimeOffset i:
+                writer.WriteTimeValue(i);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Use DynamicSerializer as default for type serializers
* Generate a type serializer for QueryVal.Serialize()
* Implement Serialize for all StructSerializers

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
* We can now implement Serialize for each type serializer with smaller PRs
* Prepares for the addition of a registry where users can call Serializer.Registry.Add(type, serializer) to be used in the serialize/deserialize paths.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Existing tests pass

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to Fauna documentation.
- [ ] My change requires a change to the README, and I have updated it accordingly.
