### PR TITLE
[DOCS-3246] docs: Cross-link to driver API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Using the .NET CLI:
 dotnet add package Fauna --prerelease
 ```
 
+## API reference
+
+API reference documentation for the driver is available at
+https://fauna.github.io/fauna-dotnet/. The docs are generated using
+[Doxygen](https://www.doxygen.nl/).
+
+
 ## Basic usage
 
 ```csharp

--- a/concourse/scripts/publish-docs.sh
+++ b/concourse/scripts/publish-docs.sh
@@ -12,17 +12,6 @@ git clone docs.git docs-updated.git
 
 cd docs-updated.git
 
-rm index.html
-echo "<section style=\"margin: 20px\">" >> index.html
-echo "<header>Current Version</header>" >> index.html
-echo "<li><a href='https://fauna.github.io/fauna-dotnet/$PACKAGE_VERSION'>$PACKAGE_VERSION</a></li>" >> index.html
-echo "</section>" >> index.html
-
-echo "<section style=\"margin: 20px\">" >> index.html
-echo "<header>All Versions</header>" >> index.html
-git --git-dir "$REPO_GIT_DIR" tag -l --sort=-v:refname | awk '{print "<li><a href=\"https://fauna.github.io/fauna-dotnet/"$0"\">"$0"</a></li>"}' >> index.html
-echo "</section>" >> index.html
-
 mkdir "${PACKAGE_VERSION}"
 cd "${PACKAGE_VERSION}"
 
@@ -55,6 +44,9 @@ BODY_GTM=$(cat ../../repo.git/concourse/scripts/body_gtm.dat)
 sed -i.bak "0,/<body>/{s/<body>/<body>${BODY_GTM}/}" ./index.html
 
 rm ./index.html.bak
+
+echo "Updating 'latest' symlink to point to $PACKAGE_VERSION"
+ln -sfn "$PACKAGE_VERSION" latest
 
 git config --global user.email "nobody@fauna.com"
 git config --global user.name "Fauna, Inc"


### PR DESCRIPTION

### Description
Ticket: [DOCS-3246](https://faunadb.atlassian.net/browse/DOCS-3246)

### Motivation and context
- We don't link to the driver API reference from the README. Users may not be aware these docs exist.
- I recently improved the API ref index. We need to update the build script to avoid overwriting the new index.
- I recently added a `latest/` symlink to the `gh-pages` branch that points to the latest release of the API ref. However, that symlink isn't updated as part of the release process.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[DOCS-3246]: https://faunadb.atlassian.net/browse/DOCS-3246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ