### PR TITLE
[DOCS-3248] bugfix: Fix API ref error

### DIFF
--- a/Fauna/Client/Configuration.cs
+++ b/Fauna/Client/Configuration.cs
@@ -4,7 +4,7 @@
 /// Configuration is a class used to configure a Fauna <see cref="Client"/>. It encapsulates various settings such as the <see cref="Endpoint"/>,
 /// secret, query timeout, and others.
 /// </summary>
-public record Configuration
+public record class Configuration
 {
     /// <summary>
     /// Whether the <see cref="Client"/> should dispose of the  <see cref="HttpClient"/> on Dispose.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description

Doxygen is unable to generate API ref docs for `Configuration.cs` without the `class` value type.

Per the [docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record), `record` and `record class` are synonymous here.

I've already manually regenerated the 0.2.0-beta docs to fix this issue. This should fix it for future releases.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
