### PR TITLE
[DOCS-3249] docs: Update API docs heading

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "Fauna .NET Driver"
+PROJECT_NAME           = "Fauna v10 .NET/C# Driver"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = 
+OUTPUT_DIRECTORY       =
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and


### PR DESCRIPTION
Updates the heading used in the driver API docs:

![Screenshot 2024-08-15 at 4 33 14 PM](https://github.com/user-attachments/assets/d128e251-1d8f-46ef-b8ab-16a03253d806)


