### PR TITLE
Add more Serializer tests from the perspective of FieldInfos on the MappingContext

### DIFF
--- a/Fauna.Test/Serialization/Serializers/ClassSerializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializers/ClassSerializer.Tests.cs
@@ -136,37 +136,19 @@ public class ClassSerializerTests
     }
 
     [Test]
-    public void DuplicateFieldNamesThrowsArgumentException()
+    [TestCase("Fauna.Test.Serialization.ClassWithDupeFields")]
+    [TestCase("Fauna.Test.Serialization.ClassWithFieldNameOverlap")]
+    public void InvalidFieldNamesThrowsArgumentException(string classWithBadFields)
     {
-        try
+        var ex = Assert.Throws<ArgumentException>(() =>
         {
-            var serializer = Serializer.Generate<ClassWithDupeFields>(_ctx);
-        }
-        catch (Exception e)
-        {
-            Assert.AreEqual(e.GetType(), typeof(ArgumentException));
-            Assert.IsTrue(e.Message.Contains("Duplicate field name"));
-            return;
-        }
+            var badClass = Type.GetType(classWithBadFields);
+            Assert.IsNotNull(badClass, $"Couldn't find Type from class name: {classWithBadFields}");
+            var serializer = Serializer.Generate(_ctx, badClass!);
+        });
 
-        Assert.Fail("Deserialization succeeded unexpectedly.");
-    }
-
-    [Test]
-    public void FieldNameOverlapThrowsArgumentException()
-    {
-        try
-        {
-            var serializer = Serializer.Generate<ClassWithFieldNameOverlap>(_ctx);
-        }
-        catch (Exception e)
-        {
-            Assert.AreEqual(e.GetType(), typeof(ArgumentException));
-            Assert.IsTrue(e.Message.Contains("Duplicate field name"));
-            return;
-        }
-
-        Assert.Fail("Deserialization succeeded unexpectedly.");
+        Assert.IsNotNull(ex);
+        Assert.IsTrue(ex!.Message.Contains("Duplicate field name"));
     }
 
     [Test]

--- a/Fauna.Test/Serialization/Serializers/ClassSerializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializers/ClassSerializer.Tests.cs
@@ -153,6 +153,23 @@ public class ClassSerializerTests
     }
 
     [Test]
+    public void FieldNameOverlapThrowsArgumentException()
+    {
+        try
+        {
+            var serializer = Serializer.Generate<ClassWithFieldNameOverlap>(_ctx);
+        }
+        catch (Exception e)
+        {
+            Assert.AreEqual(e.GetType(), typeof(ArgumentException));
+            Assert.IsTrue(e.Message.Contains("Duplicate field name"));
+            return;
+        }
+
+        Assert.Fail("Deserialization succeeded unexpectedly.");
+    }
+
+    [Test]
     public void ValidateFieldInfoOnSerializerCtx()
     {
         var mappingInfo = _ctx.GetInfo(typeof(ClassWithLotsOfFields));
@@ -166,13 +183,22 @@ public class ClassSerializerTests
             "id",
             "coll",
             "ts",
-            "string_field",
-            "int_field",
-            "float_field",
-            "double_field",
-            "bool_field",
+            "dateTimeField",
+            "dateOnlyField",
+            "dateTimeOffsetField",
+            "stringField",
+            "shortField",
+            "ushortField",
+            "intField",
+            "uintField",
+            "floatField",
+            "doubleField",
+            "longField",
+            "boolField",
+            "byteField",
+            "sbyteField",
             "nullableIntField",
-            "other_doc"
+            "otherDocRef"
         };
 
         Assert.IsNotNull(fields);
@@ -202,37 +228,82 @@ public class ClassSerializerTests
                     Assert.AreEqual(typeof(DateTime?), field.Type);
                     Assert.IsInstanceOf<NullableStructSerializer<DateTime>>(field.Serializer);
                     break;
-                case "string_field":
+                case "dateTimeField":
+                    Assert.IsFalse(field.IsNullable);
+                    Assert.AreEqual(typeof(DateTime), field.Type);
+                    Assert.IsInstanceOf<DateTimeSerializer>(field.Serializer);
+                    break;
+                case "dateOnlyField":
+                    Assert.IsFalse(field.IsNullable);
+                    Assert.AreEqual(typeof(DateOnly), field.Type);
+                    Assert.IsInstanceOf<DateOnlySerializer>(field.Serializer);
+                    break;
+                case "dateTimeOffsetField":
+                    Assert.IsFalse(field.IsNullable);
+                    Assert.AreEqual(typeof(DateTimeOffset), field.Type);
+                    Assert.IsInstanceOf<DateTimeOffsetSerializer>(field.Serializer);
+                    break;
+                case "stringField":
                     Assert.IsTrue(field.IsNullable);
                     Assert.AreEqual(typeof(string), field.Type);
                     Assert.IsInstanceOf<NullableSerializer<string>>(field.Serializer);
                     break;
-                case "int_field":
+                case "shortField":
+                    Assert.IsFalse(field.IsNullable);
+                    Assert.AreEqual(typeof(short), field.Type);
+                    Assert.IsInstanceOf<ShortSerializer>(field.Serializer);
+                    break;
+                case "ushortField":
+                    Assert.IsFalse(field.IsNullable);
+                    Assert.AreEqual(typeof(ushort), field.Type);
+                    Assert.IsInstanceOf<UShortSerializer>(field.Serializer);
+                    break;
+                case "intField":
                     Assert.IsFalse(field.IsNullable);
                     Assert.AreEqual(typeof(int), field.Type);
                     Assert.IsInstanceOf<IntSerializer>(field.Serializer);
                     break;
-                case "float_field":
+                case "uintField":
+                    Assert.IsFalse(field.IsNullable);
+                    Assert.AreEqual(typeof(uint), field.Type);
+                    Assert.IsInstanceOf<UIntSerializer>(field.Serializer);
+                    break;
+                case "floatField":
                     Assert.IsFalse(field.IsNullable);
                     Assert.AreEqual(typeof(float), field.Type);
                     Assert.IsInstanceOf<FloatSerializer>(field.Serializer);
                     break;
-                case "double_field":
+                case "doubleField":
                     Assert.IsFalse(field.IsNullable);
                     Assert.AreEqual(typeof(double), field.Type);
                     Assert.IsInstanceOf<DoubleSerializer>(field.Serializer);
                     break;
-                case "bool_field":
+                case "longField":
+                    Assert.IsFalse(field.IsNullable);
+                    Assert.AreEqual(typeof(long), field.Type);
+                    Assert.IsInstanceOf<LongSerializer>(field.Serializer);
+                    break;
+                case "boolField":
                     Assert.IsFalse(field.IsNullable);
                     Assert.AreEqual(typeof(bool), field.Type);
                     Assert.IsInstanceOf<BooleanSerializer>(field.Serializer);
+                    break;
+                case "byteField":
+                    Assert.IsFalse(field.IsNullable);
+                    Assert.AreEqual(typeof(byte), field.Type);
+                    Assert.IsInstanceOf<ByteSerializer>(field.Serializer);
+                    break;
+                case "sbyteField":
+                    Assert.IsFalse(field.IsNullable);
+                    Assert.AreEqual(typeof(sbyte), field.Type);
+                    Assert.IsInstanceOf<SByteSerializer>(field.Serializer);
                     break;
                 case "nullableIntField":
                     Assert.IsTrue(field.IsNullable);
                     Assert.AreEqual(typeof(int?), field.Type);
                     Assert.IsInstanceOf<NullableStructSerializer<int>>(field.Serializer);
                     break;
-                case "other_doc":
+                case "otherDocRef":
                     Assert.IsTrue(field.IsNullable);
                     Assert.AreEqual(typeof(ClassForDocument), field.Type);
                     Assert.IsInstanceOf<NullableSerializer<ClassForDocument>>(field.Serializer);

--- a/Fauna.Test/Serialization/TestClasses.cs
+++ b/Fauna.Test/Serialization/TestClasses.cs
@@ -180,18 +180,37 @@ class ClassWithDupeFields
 }
 
 [Object]
+class ClassWithFieldNameOverlap
+{
+    [Field] public string? Id { get; set; }
+    [Field] public Module? Coll { get; set; }
+    [Field] public DateTime? Ts { get; set; }
+    [Field("user_field")] public string? UserField { get; set; }
+    [Field] public string? user_field { get; set; }
+}
+
+[Object]
 class ClassWithLotsOfFields
 {
     [Field] public string? Id { get; set; }
     [Field] public Module? Coll { get; set; }
     [Field] public DateTime? Ts { get; set; }
-    [Field("string_field")] public string? StringField { get; set; }
-    [Field("int_field")] public int IntField { get; set; }
-    [Field("float_field")] public float FloatField { get; set; }
-    [Field("double_field")] public double DoubleField { get; set; }
-    [Field("bool_field")] public bool BoolField { get; set; }
+    [Field] public DateTime DateTimeField { get; set; }
+    [Field] public DateOnly DateOnlyField { get; set; }
+    [Field] public DateTimeOffset DateTimeOffsetField { get; set; }
+    [Field] public string? StringField { get; set; }
+    [Field] public short ShortField { get; set; }
+    [Field] public ushort UshortField { get; set; }
+    [Field] public int IntField { get; set; }
+    [Field] public uint UintField { get; set; }
+    [Field] public float FloatField { get; set; }
+    [Field] public double DoubleField { get; set; }
+    [Field] public long LongField { get; set; }
+    [Field] public bool BoolField { get; set; }
+    [Field] public byte ByteField { get; set; }
+    [Field] public sbyte SbyteField { get; set; }
     [Field] public int? NullableIntField { get; set; }
-    [Field("other_doc")] public ClassForDocument? OtherDocRef { get; set; }
+    [Field] public ClassForDocument? OtherDocRef { get; set; }
 }
 
 public class IntToStringSerializer : BaseSerializer<int>

--- a/Fauna.Test/Serialization/TestClasses.cs
+++ b/Fauna.Test/Serialization/TestClasses.cs
@@ -169,6 +169,31 @@ class PersonWithDateConflict : IOnlyField
     [Field("@date")] public string? Field { get; set; } = "not";
 }
 
+[Object]
+class ClassWithDupeFields
+{
+    [Field] public string? Id { get; set; }
+    [Field] public Module? Coll { get; set; }
+    [Field] public DateTime? Ts { get; set; }
+    [Field("user_field")] public string? UserField { get; set; }
+    [Field("user_field")] public string? UserField2 { get; set; }
+}
+
+[Object]
+class ClassWithLotsOfFields
+{
+    [Field] public string? Id { get; set; }
+    [Field] public Module? Coll { get; set; }
+    [Field] public DateTime? Ts { get; set; }
+    [Field("string_field")] public string? StringField { get; set; }
+    [Field("int_field")] public int IntField { get; set; }
+    [Field("float_field")] public float FloatField { get; set; }
+    [Field("double_field")] public double DoubleField { get; set; }
+    [Field("bool_field")] public bool BoolField { get; set; }
+    [Field] public int? NullableIntField { get; set; }
+    [Field("other_doc")] public ClassForDocument? OtherDocRef { get; set; }
+}
+
 public class IntToStringSerializer : BaseSerializer<int>
 {
     public override int Deserialize(MappingContext context, ref Utf8FaunaReader reader)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
Adding some more test coverage of the `MappingContext` and `FieldInfo` instantiation of serializers for built-in types, as well as a couple tests for duplicate field names.

### Motivation and context
More test coverage is a Good Thing.

### How was the change tested?
Ran tests locally with `dotnet test --framework net8.0` - will let the GH Action validate net6.0.

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)
* - [x] N/A (test only)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
