### PR TITLE
feat(streams): Use Cursor

### DIFF
--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -341,7 +341,7 @@ public class IntegrationTests
                 {
                     Assert.Multiple(() =>
                     {
-                        Assert.NotZero(evt.TxnTime, "should have a txn time");
+                        Assert.IsNotEmpty(evt.Cursor, "should have a cursor");
                         Assert.NotZero(evt.Stats.ReadOps, "should have consumed ReadOps");
                         if (evt.Type is EventType.Status)
                         {

--- a/Fauna/Client.cs
+++ b/Fauna/Client.cs
@@ -145,7 +145,7 @@ public class Client : BaseClient, IDisposable
                            cancel))
         {
             LastSeenTxn = evt.TxnTime;
-            stream.StartTs = evt.TxnTime;
+            stream.LastCursor = evt.Cursor;
             StatsCollector?.Add(evt.Stats);
             yield return evt;
         }

--- a/Fauna/Core/Connection.cs
+++ b/Fauna/Core/Connection.cs
@@ -81,7 +81,7 @@ internal class Connection : IConnection
                     }
 
                     var evt = Event<T>.From(line, ctx);
-                    stream.StartTs = evt.TxnTime;
+                    stream.LastCursor = evt.Cursor;
                     listener.Dispatch(evt);
                 }
 

--- a/Fauna/Core/Connection.cs
+++ b/Fauna/Core/Connection.cs
@@ -1,7 +1,10 @@
 ﻿using System.Collections.Concurrent;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
+using Fauna.Exceptions;
 using Fauna.Mapping;
+using Fauna.Serialization;
 using Fauna.Types;
 using Polly;
 using Stream = System.IO.Stream;
@@ -57,44 +60,63 @@ internal class Connection : IConnection
         while (!cancellationToken.IsCancellationRequested)
         {
             var listener = new EventListener<T>();
-            Task streamTask = _cfg.RetryConfiguration.RetryPolicy.ExecuteAndCaptureAsync(async () =>
-            {
-                var streamData = new MemoryStream();
-                stream.Serialize(streamData);
-
-                var response = await _cfg.HttpClient
-                    .SendAsync(
-                        CreateHttpRequest(path, streamData, headers),
-                        HttpCompletionOption.ResponseHeadersRead,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-
-                await using var streamAsync = await response.Content.ReadAsStreamAsync(cancellationToken);
-                using var streamReader = new StreamReader(streamAsync);
-
-                while (!streamReader.EndOfStream && !cancellationToken.IsCancellationRequested)
+            Task<PolicyResult<HttpResponseMessage>> streamTask =
+                _cfg.RetryConfiguration.RetryPolicy.ExecuteAndCaptureAsync(async () =>
                 {
-                    string? line = await streamReader.ReadLineAsync().WaitAsync(cancellationToken);
-                    if (string.IsNullOrWhiteSpace(line))
+                    var streamData = new MemoryStream();
+                    stream.Serialize(streamData);
+
+                    var response = await _cfg.HttpClient
+                        .SendAsync(
+                            CreateHttpRequest(path, streamData, headers),
+                            HttpCompletionOption.ResponseHeadersRead,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+
+                    if (!response.IsSuccessStatusCode)
                     {
-                        continue;
+                        // TRICKY: we need to break the events listener loop
+                        listener.Dispatch(null);
+                        return response;
                     }
 
-                    var evt = Event<T>.From(line, ctx);
-                    stream.LastCursor = evt.Cursor;
-                    listener.Dispatch(evt);
-                }
+                    await using var streamAsync = await response.Content.ReadAsStreamAsync(cancellationToken);
+                    using var streamReader = new StreamReader(streamAsync);
 
-                listener.Close();
-                return response;
-            });
+                    while (!streamReader.EndOfStream && !cancellationToken.IsCancellationRequested)
+                    {
+                        string? line = await streamReader.ReadLineAsync().WaitAsync(cancellationToken);
+                        if (string.IsNullOrWhiteSpace(line))
+                        {
+                            continue;
+                        }
+
+                        var evt = Event<T>.From(line, ctx);
+                        stream.LastCursor = evt.Cursor;
+                        listener.Dispatch(evt);
+                    }
+
+                    listener.Close();
+                    return response;
+                });
 
             await foreach (var evt in listener.Events().WithCancellation(cancellationToken))
             {
+                if (evt is null) break;
+
                 yield return evt;
             }
 
             await streamTask;
+            if (streamTask.Result.Result.IsSuccessStatusCode)
+            {
+                continue;
+            }
+
+            var httpResponse = streamTask.Result.Result;
+            string body = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
+
+            throw ExceptionFactory.FromRawResponse(body, httpResponse);
         }
     }
 
@@ -104,17 +126,18 @@ internal class Connection : IConnection
     /// <typeparam name="T">The type of event data.</typeparam>
     private class EventListener<T> where T : notnull
     {
-        private readonly ConcurrentQueue<Event<T>> _queue = new();
+        private readonly ConcurrentQueue<Event<T>?> _queue = new();
         private readonly SemaphoreSlim _semaphore = new(0);
         private bool _closed;
 
-        public void Dispatch(Event<T> evt)
+        public void Dispatch(Event<T>? evt)
         {
             _queue.Enqueue(evt);
             _semaphore.Release();
+            if (evt is null) Close();
         }
 
-        public async IAsyncEnumerable<Event<T>> Events()
+        public async IAsyncEnumerable<Event<T>?> Events()
         {
             while (true)
             {

--- a/Fauna/Core/ResponseFields.cs
+++ b/Fauna/Core/ResponseFields.cs
@@ -18,6 +18,11 @@ internal readonly struct ResponseFields
     public const string LastSeenTxnFieldName = "txn_ts";
 
     /// <summary>
+    /// Field name for the stream cursor of the response.
+    /// </summary>
+    public const string CursorFieldName = "cursor";
+
+    /// <summary>
     /// Field name for static type information in the response.
     /// </summary>
     public const string StaticTypeFieldName = "static_type";

--- a/Fauna/Core/StreamEnumerable.cs
+++ b/Fauna/Core/StreamEnumerable.cs
@@ -9,6 +9,8 @@ public class StreamEnumerable<T> where T : notnull
     private readonly Stream _stream;
     private readonly CancellationToken _cancel;
 
+    public string Token => _stream.Token;
+
     internal StreamEnumerable(
         BaseClient client,
         Stream stream,

--- a/Fauna/Core/StreamOptions.cs
+++ b/Fauna/Core/StreamOptions.cs
@@ -5,15 +5,38 @@ namespace Fauna;
 /// </summary>
 public class StreamOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamOptions"/> class with the specified token and cursor.
+    /// </summary>
+    /// <param name="token">The token returned from Fauna when the stream is created.</param>
+    /// <param name="cursor">The cursor from the stream, must be used with the associated Token. Used to resume the stream.</param>
+    /// <seealso href="https://docs.fauna.com/fauna/current/reference/streaming/#restart-a-stream"/>
+    public StreamOptions(string token, string cursor)
+    {
+        Token = token;
+        Cursor = cursor;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamOptions"/> class with the specified token and start timestamp.
+    /// </summary>
+    /// <param name="token">The token returned from Fauna when the stream is created.</param>
+    /// <param name="startTs">The start timestamp to use for the stream.</param>
+    public StreamOptions(string token, long startTs)
+    {
+        Token = token;
+        StartTs = startTs;
+    }
+
     // <summary>Token returned from Fauna when the stream is created.</summary>
     /// <see href="https://docs.fauna.com/fauna/current/reference/http/reference/stream/get/"/>
-    public string? Token { get; init; } = null;
+    public string? Token { get; }
 
     /// <summary>Cursor from the stream, must be used with the associated Token. Used to resume the stream.</summary>
     /// <see href="https://docs.fauna.com/fauna/current/reference/streaming/#restart-a-stream"/>
-    public string? Cursor { get; init; } = null;
+    public string? Cursor { get; }
 
     // <summary>Start timestamp from the stream, must be used with the associated Token. Used to resume the stream.</summary>
     /// <see href="https://docs.fauna.com/fauna/current/reference/streaming/#restart-a-stream"/>
-    public long? StartTs { get; set; } = null;
+    public long? StartTs { get; }
 }

--- a/Fauna/Core/StreamOptions.cs
+++ b/Fauna/Core/StreamOptions.cs
@@ -1,0 +1,19 @@
+namespace Fauna;
+
+/// <summary>
+/// Represents the options when subscribing to Fauna Streams.
+/// </summary>
+public class StreamOptions
+{
+    // <summary>Token returned from Fauna when the stream is created.</summary>
+    /// <see href="https://docs.fauna.com/fauna/current/reference/http/reference/stream/get/"/>
+    public string? Token { get; init; } = null;
+
+    /// <summary>Cursor from the stream, must be used with the associated Token. Used to resume the stream.</summary>
+    /// <see href="https://docs.fauna.com/fauna/current/reference/streaming/#restart-a-stream"/>
+    public string? Cursor { get; init; } = null;
+
+    // <summary>Start timestamp from the stream, must be used with the associated Token. Used to resume the stream.</summary>
+    /// <see href="https://docs.fauna.com/fauna/current/reference/streaming/#restart-a-stream"/>
+    public long? StartTs { get; set; } = null;
+}

--- a/Fauna/Types/Event.cs
+++ b/Fauna/Types/Event.cs
@@ -60,7 +60,7 @@ public class Event<T> where T : notnull
     {
         if (!json.TryGetProperty(CursorFieldName, out var elem))
         {
-            throw new Exception($"Missing required field: cursor - {json.ToString()}");
+            throw new InvalidDataException($"Missing required field: cursor - {json.ToString()}");
         }
 
         return elem.Deserialize<string>() ?? throw new InvalidOperationException();

--- a/Fauna/Types/Event.cs
+++ b/Fauna/Types/Event.cs
@@ -63,7 +63,7 @@ public class Event<T> where T : notnull
             throw new InvalidDataException($"Missing required field: cursor - {json.ToString()}");
         }
 
-        return elem.Deserialize<string>() ?? throw new InvalidOperationException("Failed to deserialize Cursor");
+        return elem.Deserialize<string>()!;
     }
 
 

--- a/Fauna/Types/Event.cs
+++ b/Fauna/Types/Event.cs
@@ -20,6 +20,7 @@ public class Event<T> where T : notnull
 {
     public EventType Type { get; private init; }
     public long TxnTime { get; private init; }
+    public string Cursor { get; private init; } = null!;
     public T? Data { get; private init; }
     public QueryStats Stats { get; private init; }
 
@@ -36,6 +37,7 @@ public class Event<T> where T : notnull
         var evt = new Event<T>
         {
             TxnTime = GetTxnTime(json),
+            Cursor = GetCursor(json),
             Type = GetType(json),
             Stats = GetStats(json),
             Data = GetData(json, ctx),
@@ -53,6 +55,17 @@ public class Event<T> where T : notnull
 
         return elem.TryGetInt64(out long i) ? i : default;
     }
+
+    private static string GetCursor(JsonElement json)
+    {
+        if (!json.TryGetProperty(CursorFieldName, out var elem))
+        {
+            throw new Exception($"Missing required field: cursor - {json.ToString()}");
+        }
+
+        return elem.Deserialize<string>() ?? throw new InvalidOperationException();
+    }
+
 
     private static EventType GetType(JsonElement json)
     {

--- a/Fauna/Types/Event.cs
+++ b/Fauna/Types/Event.cs
@@ -63,7 +63,7 @@ public class Event<T> where T : notnull
             throw new InvalidDataException($"Missing required field: cursor - {json.ToString()}");
         }
 
-        return elem.Deserialize<string>() ?? throw new InvalidOperationException();
+        return elem.Deserialize<string>() ?? throw new InvalidOperationException("Failed to deserialize Cursor");
     }
 
 

--- a/Fauna/Types/Stream.cs
+++ b/Fauna/Types/Stream.cs
@@ -15,7 +15,7 @@ public sealed class Stream : IEquatable<Stream>
     /// <summary>
     /// Gets the string value of the stream token.
     /// </summary>
-    private string Token { get; }
+    internal string Token { get; }
 
     public long? StartTs { get; set; }
 

--- a/Fauna/Types/Stream.cs
+++ b/Fauna/Types/Stream.cs
@@ -26,13 +26,13 @@ public sealed class Stream : IEquatable<Stream>
         var writer = new Utf8JsonWriter(stream);
         writer.WriteStartObject();
         writer.WriteString("token", Token);
-        if (StartTs != null)
-        {
-            writer.WriteNumber("start_ts", StartTs.Value);
-        }
         if (LastCursor != null)
         {
             writer.WriteString("cursor", LastCursor);
+        }
+        else if (StartTs != null)
+        {
+            writer.WriteNumber("start_ts", StartTs.Value);
         }
         writer.WriteEndObject();
         writer.Flush();

--- a/Fauna/Types/Stream.cs
+++ b/Fauna/Types/Stream.cs
@@ -19,6 +19,8 @@ public sealed class Stream : IEquatable<Stream>
 
     public long? StartTs { get; set; }
 
+    public string? LastCursor { get; set; }
+
     public void Serialize(System.IO.Stream stream)
     {
         var writer = new Utf8JsonWriter(stream);
@@ -27,6 +29,10 @@ public sealed class Stream : IEquatable<Stream>
         if (StartTs != null)
         {
             writer.WriteNumber("start_ts", StartTs.Value);
+        }
+        if (LastCursor != null)
+        {
+            writer.WriteString("cursor", LastCursor);
         }
         writer.WriteEndObject();
         writer.Flush();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description

Provide support for the new per-event stream cursor.

### Motivation and context

There's an edge case where resuming a stream from a txn time with lots of documents written could result in event loss. This approach fixes that edge case.

### How was the change tested?

Updated integration test

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
