### PR TITLE
feat(streaming): Add StreamOptions

### DIFF
--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -386,4 +386,96 @@ public class IntegrationTests
 
         await Task.CompletedTask;
     }
+
+    [Test]
+    [Category("Streaming")]
+    public Task StreamThrowsWithoutToken()
+    {
+        var ex = Assert.ThrowsAsync<Exception>(async () =>
+            await _client.EventStreamAsync<StreamingSandbox>(FQL($"StreamingSandbox.all()"),
+                streamOptions: new StreamOptions { Cursor = "abc1234==" }));
+        Assert.AreSame("The 'cursor' configuration can only be used with a stream token.", ex?.Message);
+
+        return Task.CompletedTask;
+    }
+
+    [Test]
+    [Category("Streaming")]
+    public async Task CanResumeStreamWithStreamOptions()
+    {
+        string? token = null;
+        string? cursor = null;
+
+        var queries = new[]
+        {
+            FQL($"StreamingSandbox.create({{ foo: 'bar' }})"),
+            FQL($"StreamingSandbox.all().forEach(.update({{ foo: 'baz' }}))"),
+            FQL($"StreamingSandbox.all().forEach(.delete())")
+        };
+
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)); // prevent runaway test
+        cts.Token.ThrowIfCancellationRequested();
+
+        int expectedEvents = queries.Length + 1;
+
+        // create a task to open the stream and process events
+        var streamTask = Task.Run(() =>
+        {
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                var stream = await _client.EventStreamAsync<StreamingSandbox>(
+                    FQL($"StreamingSandbox.all().toStream()"),
+                    cancellationToken: cts.Token
+                );
+                Assert.NotNull(stream);
+                token = stream.Token;
+
+                await foreach (var evt in stream)
+                {
+                    // break after the first received event
+                    cursor = evt.Cursor;
+                    // ReSharper disable once AccessToModifiedClosure
+                    expectedEvents--;
+                    break;
+                }
+            });
+        }, cts.Token);
+
+        // invoke queries on a delay to simulate streaming events
+        var queryTasks = queries.Select(
+            (query, index) => Task.Delay((index + 1) * 500, cts.Token)
+                .ContinueWith(
+                    _ =>
+                    {
+                        Assert.DoesNotThrowAsync(async () => { await _client.QueryAsync(query, cancel: cts.Token); },
+                            "Should successfully invoke query");
+                    }, TaskContinuationOptions.ExecuteSynchronously));
+
+        // wait for all tasks
+        queryTasks = queryTasks.Append(streamTask);
+        Task.WaitAll(queryTasks.ToArray(), cts.Token);
+
+        Assert.NotNull(cursor, "should have a cursor from the first event");
+
+        var stream = await _client.EventStreamAsync<StreamingSandbox>(
+            FQL($"StreamingSandbox.all().toStream()"),
+            streamOptions: new StreamOptions { Token = token, Cursor = cursor },
+            cancellationToken: cts.Token
+        );
+        Assert.NotNull(stream);
+
+        await foreach (var evt in stream)
+        {
+            Assert.IsNotEmpty(evt.Cursor, "should have a cursor");
+            expectedEvents--;
+            if (expectedEvents > 0)
+            {
+                continue;
+            }
+
+            break;
+        }
+
+        Assert.Zero(expectedEvents, "stream handler should process all events");
+    }
 }

--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -391,7 +391,7 @@ public class IntegrationTests
     [Category("Streaming")]
     public Task StreamThrowsWithoutToken()
     {
-        var ex = Assert.ThrowsAsync<Exception>(async () =>
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
             await _client.EventStreamAsync<StreamingSandbox>(FQL($"StreamingSandbox.all()"),
                 streamOptions: new StreamOptions { Cursor = "abc1234==" }));
         Assert.AreSame("The 'cursor' configuration can only be used with a stream token.", ex?.Message);

--- a/Fauna/Core/Connection.cs
+++ b/Fauna/Core/Connection.cs
@@ -1,7 +1,10 @@
 ﻿using System.Collections.Concurrent;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
+using Fauna.Exceptions;
 using Fauna.Mapping;
+using Fauna.Serialization;
 using Fauna.Types;
 using Polly;
 using Stream = System.IO.Stream;
@@ -57,44 +60,63 @@ internal class Connection : IConnection
         while (!cancellationToken.IsCancellationRequested)
         {
             var listener = new EventListener<T>();
-            Task streamTask = _cfg.RetryConfiguration.RetryPolicy.ExecuteAndCaptureAsync(async () =>
-            {
-                var streamData = new MemoryStream();
-                stream.Serialize(streamData);
-
-                var response = await _cfg.HttpClient
-                    .SendAsync(
-                        CreateHttpRequest(path, streamData, headers),
-                        HttpCompletionOption.ResponseHeadersRead,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-
-                await using var streamAsync = await response.Content.ReadAsStreamAsync(cancellationToken);
-                using var streamReader = new StreamReader(streamAsync);
-
-                while (!streamReader.EndOfStream && !cancellationToken.IsCancellationRequested)
+            Task<PolicyResult<HttpResponseMessage>> streamTask =
+                _cfg.RetryConfiguration.RetryPolicy.ExecuteAndCaptureAsync(async () =>
                 {
-                    string? line = await streamReader.ReadLineAsync().WaitAsync(cancellationToken);
-                    if (string.IsNullOrWhiteSpace(line))
+                    var streamData = new MemoryStream();
+                    stream.Serialize(streamData);
+
+                    var response = await _cfg.HttpClient
+                        .SendAsync(
+                            CreateHttpRequest(path, streamData, headers),
+                            HttpCompletionOption.ResponseHeadersRead,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+
+                    if (!response.IsSuccessStatusCode)
                     {
-                        continue;
+                        // TRICKY: we need to break the events listener loop
+                        listener.Dispatch(null);
+                        return response;
                     }
 
-                    var evt = Event<T>.From(line, ctx);
-                    stream.LastCursor = evt.Cursor;
-                    listener.Dispatch(evt);
-                }
+                    await using var streamAsync = await response.Content.ReadAsStreamAsync(cancellationToken);
+                    using var streamReader = new StreamReader(streamAsync);
 
-                listener.Close();
-                return response;
-            });
+                    while (!streamReader.EndOfStream && !cancellationToken.IsCancellationRequested)
+                    {
+                        string? line = await streamReader.ReadLineAsync().WaitAsync(cancellationToken);
+                        if (string.IsNullOrWhiteSpace(line))
+                        {
+                            continue;
+                        }
+
+                        var evt = Event<T>.From(line, ctx);
+                        stream.LastCursor = evt.Cursor;
+                        listener.Dispatch(evt);
+                    }
+
+                    listener.Close();
+                    return response;
+                });
 
             await foreach (var evt in listener.Events().WithCancellation(cancellationToken))
             {
+                if (evt is null) break;
+
                 yield return evt;
             }
 
             await streamTask;
+            if (streamTask.Result.Result.IsSuccessStatusCode)
+            {
+                continue;
+            }
+
+            var httpResponse = streamTask.Result.Result;
+            string body = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
+
+            throw ExceptionFactory.FromRawResponse(body, httpResponse);
         }
     }
 
@@ -104,17 +126,18 @@ internal class Connection : IConnection
     /// <typeparam name="T">The type of event data.</typeparam>
     private class EventListener<T> where T : notnull
     {
-        private readonly ConcurrentQueue<Event<T>> _queue = new();
+        private readonly ConcurrentQueue<Event<T>?> _queue = new();
         private readonly SemaphoreSlim _semaphore = new(0);
         private bool _closed;
 
-        public void Dispatch(Event<T> evt)
+        public void Dispatch(Event<T>? evt)
         {
             _queue.Enqueue(evt);
             _semaphore.Release();
+            if (evt is null) Close();
         }
 
-        public async IAsyncEnumerable<Event<T>> Events()
+        public async IAsyncEnumerable<Event<T>?> Events()
         {
             while (true)
             {

--- a/Fauna/Core/StreamEnumerable.cs
+++ b/Fauna/Core/StreamEnumerable.cs
@@ -9,6 +9,8 @@ public class StreamEnumerable<T> where T : notnull
     private readonly Stream _stream;
     private readonly CancellationToken _cancel;
 
+    public string Token => _stream.Token;
+
     internal StreamEnumerable(
         BaseClient client,
         Stream stream,

--- a/Fauna/Core/StreamOptions.cs
+++ b/Fauna/Core/StreamOptions.cs
@@ -12,4 +12,8 @@ public class StreamOptions
     /// <summary>Cursor from the stream, must be used with the associated Token. Used to resume the stream.</summary>
     /// <see href="https://docs.fauna.com/fauna/current/reference/streaming/#restart-a-stream"/>
     public string? Cursor { get; init; } = null;
+
+    // <summary>Start timestamp from the stream, must be used with the associated Token. Used to resume the stream.</summary>
+    /// <see href="https://docs.fauna.com/fauna/current/reference/streaming/#restart-a-stream"/>
+    public long? StartTs { get; set; } = null;
 }

--- a/Fauna/Core/StreamOptions.cs
+++ b/Fauna/Core/StreamOptions.cs
@@ -1,0 +1,15 @@
+namespace Fauna;
+
+/// <summary>
+/// Represents the options when subscribing to Fauna Streams.
+/// </summary>
+public class StreamOptions
+{
+    // <summary>Token returned from Fauna when the stream is created.</summary>
+    /// <see href="https://docs.fauna.com/fauna/current/reference/http/reference/stream/get/"/>
+    public string? Token { get; init; } = null;
+
+    /// <summary>Cursor from the stream, must be used with the associated Token. Used to resume the stream.</summary>
+    /// <see href="https://docs.fauna.com/fauna/current/reference/streaming/#restart-a-stream"/>
+    public string? Cursor { get; init; } = null;
+}

--- a/Fauna/IClient.cs
+++ b/Fauna/IClient.cs
@@ -337,7 +337,6 @@ interface IClient
         ISerializer elemSerializer,
         QueryOptions? queryOptions = null,
         CancellationToken cancel = default);
-
 }
 
 /// <summary>
@@ -345,7 +344,9 @@ interface IClient
 /// </summary>
 public abstract class BaseClient : IClient
 {
-    internal BaseClient() { }
+    internal BaseClient()
+    {
+    }
 
     internal abstract MappingContext MappingCtx { get; }
 
@@ -520,21 +521,41 @@ public abstract class BaseClient : IClient
     /// <typeparam name="T">Event Data will be deserialized to this type.</typeparam>
     /// <param name="query">The query to create the stream from Fauna.</param>
     /// <param name="queryOptions">The options for the query.</param>
+    /// <param name="streamOptions"></param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a stream of events.</returns>
     public async Task<StreamEnumerable<T>> EventStreamAsync<T>(
         Query query,
         QueryOptions? queryOptions = null,
+        StreamOptions? streamOptions = null,
         CancellationToken cancellationToken = default) where T : notnull
     {
-        var response = await QueryAsync<Stream>(
-            query,
-            queryOptions,
-            cancellationToken);
+        Stream stream;
+
+        if (streamOptions?.Token is null)
+        {
+            if (streamOptions?.Cursor is not null)
+            {
+                throw new Exception("The 'cursor' configuration can only be used with a stream token.");
+            }
+
+            var response = await QueryAsync<Stream>(
+                query,
+                queryOptions,
+                cancellationToken);
+
+            stream = response.Data;
+        }
+        else
+        {
+            stream = new Stream(streamOptions.Token!);
+        }
+
+        stream.LastCursor = streamOptions?.Cursor;
 
         return new StreamEnumerable<T>(
             this,
-            response.Data,
+            stream,
             cancellationToken);
     }
 
@@ -543,7 +564,7 @@ public abstract class BaseClient : IClient
     /// </summary>
     /// <typeparam name="T">Event Data will be deserialized to this type.</typeparam>
     /// <param name="stream">The stream to subscribe to.</param>
-    /// <param name="ctx">Mapping context for stream.</param?
+    /// <param name="ctx">Mapping context for stream.</param>
     /// <param name="cancel">The cancellation token.</param>
     /// <returns>An async enumerator of stream events.</returns>
     public IAsyncEnumerator<Event<T>> SubscribeStream<T>(

--- a/Fauna/IClient.cs
+++ b/Fauna/IClient.cs
@@ -521,7 +521,7 @@ public abstract class BaseClient : IClient
     /// <typeparam name="T">Event Data will be deserialized to this type.</typeparam>
     /// <param name="query">The query to create the stream from Fauna.</param>
     /// <param name="queryOptions">The options for the query.</param>
-    /// <param name="streamOptions"></param>
+    /// <param name="streamOptions">The options for the stream.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a stream of events.</returns>
     public async Task<StreamEnumerable<T>> EventStreamAsync<T>(

--- a/Fauna/IClient.cs
+++ b/Fauna/IClient.cs
@@ -536,7 +536,7 @@ public abstract class BaseClient : IClient
         {
             if (streamOptions?.Cursor is not null)
             {
-                throw new Exception("The 'cursor' configuration can only be used with a stream token.");
+                throw new ArgumentException("The 'cursor' configuration can only be used with a stream token.");
             }
 
             var response = await QueryAsync<Stream>(

--- a/Fauna/IClient.cs
+++ b/Fauna/IClient.cs
@@ -552,6 +552,7 @@ public abstract class BaseClient : IClient
         }
 
         stream.LastCursor = streamOptions?.Cursor;
+        stream.StartTs = streamOptions?.StartTs;
 
         return new StreamEnumerable<T>(
             this,

--- a/Fauna/Types/Stream.cs
+++ b/Fauna/Types/Stream.cs
@@ -15,7 +15,7 @@ public sealed class Stream : IEquatable<Stream>
     /// <summary>
     /// Gets the string value of the stream token.
     /// </summary>
-    private string Token { get; }
+    internal string Token { get; }
 
     public long? StartTs { get; set; }
 
@@ -33,10 +33,6 @@ public sealed class Stream : IEquatable<Stream>
         else if (StartTs != null)
         {
             writer.WriteNumber("start_ts", StartTs.Value);
-        }
-        if (LastCursor != null)
-        {
-            writer.WriteString("cursor", LastCursor);
         }
         writer.WriteEndObject();
         writer.Flush();

--- a/Fauna/Types/Stream.cs
+++ b/Fauna/Types/Stream.cs
@@ -34,6 +34,10 @@ public sealed class Stream : IEquatable<Stream>
         {
             writer.WriteNumber("start_ts", StartTs.Value);
         }
+        if (LastCursor != null)
+        {
+            writer.WriteString("cursor", LastCursor);
+        }
         writer.WriteEndObject();
         writer.Flush();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description

Add `StreamOptions` to enable consumers to resume a Stream.

### Motivation and context

Consumers need to provide the `Token` and `Cursor` in order to resume a Stream. 

### How was the change tested?

Included additional Integration Tests

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
