### PR TITLE
feat(serialization): Add Query fragments to Serializer

### DIFF
--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -201,36 +201,6 @@ public class IntegrationTests
     }
 
     [Test]
-    [Category("serialization")]
-    public void ValidateUnwrappedListOfQueriesError()
-    {
-        var q = new List<Query>
-        {
-            FQL($"4 + 2"),
-            FQL($"5 + 2"),
-            FQL($"6 + 2"),
-        };
-
-        var ex = Assert.ThrowsAsync<ArgumentException>(async () => await _client.QueryAsync<List<int>>(FQL($"{q}")));
-        Assert.AreEqual("Use QueryArr to wrap a List<Query>", ex!.Message);
-    }
-
-    [Test]
-    [Category("serialization")]
-    public void ValidateUnwrappedMapOfQueriesError()
-    {
-        var q = new Dictionary<string, Query>
-        {
-            {"six", FQL($"4 + 2") },
-            {"seven", FQL($"5 + 2") },
-            {"eight", FQL($"6 + 2")},
-        };
-
-        var ex = Assert.ThrowsAsync<ArgumentException>(async () => await _client.QueryAsync<Dictionary<string, int>>(FQL($"{q}")));
-        Assert.AreEqual("Use QueryObj to wrap a Dictionary<str, Query>", ex!.Message);
-    }
-
-    [Test]
     public async Task Paginate_IteratorCanBeFlattened()
     {
         var items = new List<Person>();

--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -142,6 +142,95 @@ public class IntegrationTests
     }
 
     [Test]
+    [Category("serialization")]
+    public async Task ValidateQueryArray()
+    {
+        var q = new List<Query> { FQL($"4 + 2"), FQL($"5 + 2"), FQL($"6 + 2"), };
+        var obj = new QueryArr(q);
+
+        var result = await _client.QueryAsync<List<int>>(FQL($"{obj}"));
+
+        Assert.AreEqual(new List<int> { 6, 7, 8 }, result.Data);
+    }
+
+    [Test]
+    [Category("serialization")]
+    public async Task ValidateQueryObject()
+    {
+        var q = new Dictionary<string, Query>
+        {
+            { "six", FQL($"4 + 2") },
+            { "seven", FQL($"5 + 2") },
+            { "eight", FQL($"6 + 2")},
+        };
+        var obj = new QueryObj(q);
+
+        var result = await _client.QueryAsync<Dictionary<string, int>>(FQL($"{obj}"));
+
+        Assert.AreEqual(new Dictionary<string, int>
+        {
+            { "six", 6 },
+            { "seven", 7 },
+            { "eight", 8 }
+        }, result.Data);
+    }
+
+
+    private class ClassWithQuery
+    {
+        private Query Query { get; }
+
+        public ClassWithQuery(Query query)
+        {
+            Query = query;
+        }
+
+        public override string? ToString() => Query.ToString();
+    }
+
+    [Test]
+    [Category("serialization")]
+    public async Task ValidateQueryObjectWithClass()
+    {
+        var q = new ClassWithQuery(FQL($"4 + 4"));
+        var obj = new QueryObj(q);
+
+        var result = await _client.QueryAsync<int>(FQL($"{obj}"));
+
+        Assert.AreEqual(8, result.Data);
+    }
+
+    [Test]
+    [Category("serialization")]
+    public void ValidateUnwrappedListOfQueriesError()
+    {
+        var q = new List<Query>
+        {
+            FQL($"4 + 2"),
+            FQL($"5 + 2"),
+            FQL($"6 + 2"),
+        };
+
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () => await _client.QueryAsync<List<int>>(FQL($"{q}")));
+        Assert.AreEqual("Use QueryArr to wrap a List<Query>", ex!.Message);
+    }
+
+    [Test]
+    [Category("serialization")]
+    public void ValidateUnwrappedMapOfQueriesError()
+    {
+        var q = new Dictionary<string, Query>
+        {
+            {"six", FQL($"4 + 2") },
+            {"seven", FQL($"5 + 2") },
+            {"eight", FQL($"6 + 2")},
+        };
+
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () => await _client.QueryAsync<Dictionary<string, int>>(FQL($"{q}")));
+        Assert.AreEqual("Use QueryObj to wrap a Dictionary<str, Query>", ex!.Message);
+    }
+
+    [Test]
     public async Task Paginate_IteratorCanBeFlattened()
     {
         var items = new List<Person>();

--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -175,31 +175,6 @@ public class IntegrationTests
         }, result.Data);
     }
 
-
-    private class ClassWithQuery
-    {
-        private Query Query { get; }
-
-        public ClassWithQuery(Query query)
-        {
-            Query = query;
-        }
-
-        public override string? ToString() => Query.ToString();
-    }
-
-    [Test]
-    [Category("serialization")]
-    public async Task ValidateQueryObjectWithClass()
-    {
-        var q = new ClassWithQuery(FQL($"4 + 4"));
-        var obj = new QueryObj(q);
-
-        var result = await _client.QueryAsync<int>(FQL($"{obj}"));
-
-        Assert.AreEqual(8, result.Data);
-    }
-
     [Test]
     public async Task Paginate_IteratorCanBeFlattened()
     {

--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -155,6 +155,18 @@ public class IntegrationTests
 
     [Test]
     [Category("serialization")]
+    public async Task ValidateQueryArrayWithQueryVal()
+    {
+        var q = new List<Query> { new QueryVal(6), FQL($"5 + 2"), FQL($"6 + 2"), };
+        var obj = new QueryArr(q);
+
+        var result = await _client.QueryAsync<List<int>>(FQL($"{obj}"));
+
+        Assert.AreEqual(new List<int> { 6, 7, 8 }, result.Data);
+    }
+
+    [Test]
+    [Category("serialization")]
     public async Task ValidateQueryObject()
     {
         var q = new Dictionary<string, Query>

--- a/Fauna/Query/QueryArr.cs
+++ b/Fauna/Query/QueryArr.cs
@@ -6,34 +6,22 @@ namespace Fauna;
 
 internal sealed class QueryArr : Query, IQueryFragment
 {
-    public QueryArr(IEnumerable<object?> v)
+    public QueryArr(IEnumerable<Query> v)
     {
-        if (v == null)
-        {
-            throw new ArgumentNullException(nameof(v), "Value cannot be null.");
-        }
-
         Unwrap = v;
     }
 
-    public IEnumerable<object?> Unwrap { get; }
+    public IEnumerable<Query> Unwrap { get; }
 
     public override void Serialize(MappingContext ctx, Utf8FaunaWriter writer)
     {
         writer.WriteStartObject();
         writer.WriteFieldName("array");
         writer.WriteStartArray();
-        foreach (object? t in Unwrap)
+        foreach (Query t in Unwrap)
         {
-            if (t is IQueryFragment frag)
-            {
-                frag.Serialize(ctx, writer);
-            }
-            else
-            {
-                var ser = t is not null ? Serializer.Generate(ctx, t.GetType()) : DynamicSerializer.Singleton;
-                ser.Serialize(ctx, writer, t);
-            }
+            var ser = Serializer.Generate(ctx, t.GetType());
+            ser.Serialize(ctx, writer, t);
         }
         writer.WriteEndArray();
         writer.WriteEndObject();

--- a/Fauna/Query/QueryArr.cs
+++ b/Fauna/Query/QueryArr.cs
@@ -1,18 +1,33 @@
-﻿using System.Collections;
-using Fauna.Mapping;
+﻿using Fauna.Mapping;
 using Fauna.Serialization;
 
 namespace Fauna;
 
+/// <summary>
+/// Represents an array of FQL queries.
+/// </summary>
 internal sealed class QueryArr : Query, IQueryFragment
 {
+    /// <summary>
+    /// Gets the value of the specified type represented in the query.
+    /// </summary>
+    public IEnumerable<Query> Unwrap { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the QueryArr class with the specified value.
+    /// </summary>
+    /// <param name="v">The value of the specified type to be represented in the query.</param>
     public QueryArr(IEnumerable<Query> v)
     {
         Unwrap = v;
     }
 
-    public IEnumerable<Query> Unwrap { get; }
 
+    /// <summary>
+    /// Serializes the query value.
+    /// </summary>
+    /// <param name="ctx">The serialization context.</param>
+    /// <param name="writer">The writer to serialize the query value to.</param>
     public override void Serialize(MappingContext ctx, Utf8FaunaWriter writer)
     {
         writer.WriteStartObject();
@@ -27,21 +42,39 @@ internal sealed class QueryArr : Query, IQueryFragment
         writer.WriteEndObject();
     }
 
+    /// <summary>
+    /// Determines whether the specified QueryArr is equal to the current QueryArr.
+    /// </summary>
+    /// <param name="o">The QueryArr to compare with the current QueryArr.</param>
+    /// <returns>true if the specified QueryArr is equal to the current QueryArr; otherwise, false.</returns>
     public override bool Equals(Query? o)
     {
         return o is QueryArr other && Unwrap.SequenceEqual(other.Unwrap);
     }
 
+    /// <summary>
+    /// Determines whether the specified object is equal to the current QueryArr.
+    /// </summary>
+    /// <param name="otherObject">The object to compare with the current QueryArr.</param>
+    /// <returns>true if the specified object is equal to the current QueryArr; otherwise, false.</returns>
     public override bool Equals(object? otherObject)
     {
-        return Equals(otherObject as Query);
+        return Equals(otherObject as QueryArr);
     }
 
+    /// <summary>
+    /// The default hash function.
+    /// </summary>
+    /// <returns>A hash code for the current QueryArr.</returns>
     public override int GetHashCode()
     {
         return Unwrap.GetHashCode();
     }
 
+    /// <summary>
+    /// Returns a string that represents the current QueryArr.
+    /// </summary>
+    /// <returns>A string that represents the current QueryArr.</returns>
     public override string ToString()
     {
         return $"QueryArr({string.Join(", ", Unwrap)})";

--- a/Fauna/Query/QueryObj.cs
+++ b/Fauna/Query/QueryObj.cs
@@ -11,13 +11,13 @@ public sealed class QueryObj : Query, IQueryFragment
     /// <summary>
     /// Gets the value of the specified type represented in the query.
     /// </summary>
-    public object Unwrap { get; }
+    public IDictionary<string, Query> Unwrap { get; }
 
     /// <summary>
     /// Initializes a new instance of the QueryObj class with the specified value.
     /// </summary>
     /// <param name="v">The value of the specified type to be represented in the query.</param>
-    public QueryObj(object v)
+    public QueryObj(IDictionary<string, Query> v)
     {
         Unwrap = v;
     }

--- a/Fauna/Query/QueryObj.cs
+++ b/Fauna/Query/QueryObj.cs
@@ -4,7 +4,7 @@ using Fauna.Serialization;
 namespace Fauna;
 
 /// <summary>
-/// Represents a generic value holder for FQL queries. This class allows embedding values of various types into the query, with support for primitives, POCOs, and other types.
+/// Represents a dictionary of FQL queries.
 /// </summary>
 public sealed class QueryObj : Query, IQueryFragment
 {
@@ -47,12 +47,7 @@ public sealed class QueryObj : Query, IQueryFragment
     /// <returns>true if the specified object is equal to the current QueryObj; otherwise, false.</returns>
     public override bool Equals(object? o)
     {
-        if (ReferenceEquals(this, o))
-        {
-            return true;
-        }
-
-        return IsEqual(o as QueryObj);
+        return ReferenceEquals(this, o) || IsEqual(o as QueryObj);
     }
 
     /// <summary>
@@ -61,12 +56,9 @@ public sealed class QueryObj : Query, IQueryFragment
     /// <returns>A hash code for the current QueryObj.</returns>
     public override int GetHashCode()
     {
-        var hash = 31;
+        int hash = 31;
 
-        if (Unwrap is not null)
-        {
-            hash *= Unwrap.GetHashCode();
-        }
+        hash *= Unwrap.GetHashCode();
 
         return hash;
     }
@@ -85,17 +77,7 @@ public sealed class QueryObj : Query, IQueryFragment
     /// <returns>true if left and right are equal; otherwise, false.</returns>
     public static bool operator ==(QueryObj left, QueryObj right)
     {
-        if (ReferenceEquals(left, right))
-        {
-            return true;
-        }
-
-        if (left is null || right is null)
-        {
-            return false;
-        }
-
-        return left.Equals(right);
+        return ReferenceEquals(left, right) || left.Equals(right);
     }
 
     /// <summary>
@@ -111,16 +93,6 @@ public sealed class QueryObj : Query, IQueryFragment
 
     private bool IsEqual(QueryObj? o)
     {
-        if (o is null)
-        {
-            return false;
-        }
-
-        if (Unwrap is null)
-        {
-            return (o.Unwrap is null) ? true : false;
-        }
-
-        return Unwrap.Equals(o.Unwrap);
+        return o is not null && Unwrap.Equals(o.Unwrap);
     }
 }

--- a/Fauna/Query/QueryObj.cs
+++ b/Fauna/Query/QueryObj.cs
@@ -1,0 +1,126 @@
+using Fauna.Mapping;
+using Fauna.Serialization;
+
+namespace Fauna;
+
+/// <summary>
+/// Represents a generic value holder for FQL queries. This class allows embedding values of various types into the query, with support for primitives, POCOs, and other types.
+/// </summary>
+public sealed class QueryObj : Query, IQueryFragment
+{
+    /// <summary>
+    /// Gets the value of the specified type represented in the query.
+    /// </summary>
+    public object Unwrap { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the QueryObj class with the specified value.
+    /// </summary>
+    /// <param name="v">The value of the specified type to be represented in the query.</param>
+    public QueryObj(object v)
+    {
+        Unwrap = v;
+    }
+
+    /// <summary>
+    /// Serializes the query value.
+    /// </summary>
+    /// <param name="ctx">The serialization context.</param>
+    /// <param name="writer">The writer to serialize the query value to.</param>
+    public override void Serialize(MappingContext ctx, Utf8FaunaWriter writer)
+    {
+        var ser = Serializer.Generate(ctx, GetType());
+        ser.Serialize(ctx, writer, this);
+    }
+
+    /// <summary>
+    /// Determines whether the specified QueryObj is equal to the current QueryObj.
+    /// </summary>
+    /// <param name="o">The QueryObj to compare with the current QueryObj.</param>
+    /// <returns>true if the specified QueryObj is equal to the current QueryObj; otherwise, false.</returns>
+    public override bool Equals(Query? o) => IsEqual(o as QueryObj);
+
+    /// <summary>
+    /// Determines whether the specified object is equal to the current QueryObj.
+    /// </summary>
+    /// <param name="o">The object to compare with the current QueryObj.</param>
+    /// <returns>true if the specified object is equal to the current QueryObj; otherwise, false.</returns>
+    public override bool Equals(object? o)
+    {
+        if (ReferenceEquals(this, o))
+        {
+            return true;
+        }
+
+        return IsEqual(o as QueryObj);
+    }
+
+    /// <summary>
+    /// The default hash function.
+    /// </summary>
+    /// <returns>A hash code for the current QueryObj.</returns>
+    public override int GetHashCode()
+    {
+        var hash = 31;
+
+        if (Unwrap is not null)
+        {
+            hash *= Unwrap.GetHashCode();
+        }
+
+        return hash;
+    }
+
+    /// <summary>
+    /// Returns a string that represents the current QueryObj.
+    /// </summary>
+    /// <returns>A string that represents the current QueryObj.</returns>
+    public override string ToString() => $"QueryObj({Unwrap})";
+
+    /// <summary>
+    /// Determines whether two specified instances of QueryObj are equal.
+    /// </summary>
+    /// <param name="left">The first QueryObj to compare.</param>
+    /// <param name="right">The second QueryObj to compare.</param>
+    /// <returns>true if left and right are equal; otherwise, false.</returns>
+    public static bool operator ==(QueryObj left, QueryObj right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Determines whether two specified instances of QueryObj are not equal.
+    /// </summary>
+    /// <param name="left">The first QueryObj to compare.</param>
+    /// <param name="right">The second QueryObj to compare.</param>
+    /// <returns>true if left and right are not equal; otherwise, false.</returns>
+    public static bool operator !=(QueryObj left, QueryObj right)
+    {
+        return !(left == right);
+    }
+
+    private bool IsEqual(QueryObj? o)
+    {
+        if (o is null)
+        {
+            return false;
+        }
+
+        if (Unwrap is null)
+        {
+            return (o.Unwrap is null) ? true : false;
+        }
+
+        return Unwrap.Equals(o.Unwrap);
+    }
+}

--- a/Fauna/Query/QueryStringHandler.cs
+++ b/Fauna/Query/QueryStringHandler.cs
@@ -35,9 +35,9 @@ public ref struct QueryStringHandler
     /// <param name="value">The value to append.</param>
     public void AppendFormatted(object? value)
     {
-        if (value is QueryExpr expr)
+        if (value is IQueryFragment frag)
         {
-            _fragments.Add(expr);
+            _fragments.Add(frag);
         }
         else
         {

--- a/Fauna/Serialization/DictionarySerializer.cs
+++ b/Fauna/Serialization/DictionarySerializer.cs
@@ -36,6 +36,29 @@ internal class DictionarySerializer<T> : BaseSerializer<Dictionary<string, T>>
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
     {
-        DynamicSerializer.Singleton.Serialize(context, writer, o);
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case Dictionary<string, T> d:
+                bool shouldEscape = Serializer.Tags.Overlaps(d.Keys);
+                if (shouldEscape) writer.WriteStartEscapedObject();
+                else writer.WriteStartObject();
+                foreach (var (key, value) in d)
+                {
+                    writer.WriteFieldName(key);
+                    _elemSerializer.Serialize(context, writer, value);
+                }
+
+                if (shouldEscape) writer.WriteEndEscapedObject();
+                else writer.WriteEndObject();
+                break;
+            default:
+                throw new NotImplementedException();
+        }
+
+
+
     }
 }

--- a/Fauna/Serialization/DynamicSerializer.cs
+++ b/Fauna/Serialization/DynamicSerializer.cs
@@ -13,6 +13,9 @@ internal class DynamicSerializer : BaseSerializer<object?>
     private readonly DictionarySerializer<object?> _dict;
     private readonly DocumentSerializer<object> _doc;
     private readonly DocumentSerializer<object> _ref;
+    private readonly QuerySerializer _query;
+
+
 
     private DynamicSerializer()
     {
@@ -21,6 +24,7 @@ internal class DynamicSerializer : BaseSerializer<object?>
         _dict = new DictionarySerializer<object?>(this);
         _doc = new DocumentSerializer<object>();
         _ref = new DocumentSerializer<object>();
+        _query = new QuerySerializer();
     }
 
     public override object? Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
@@ -115,6 +119,9 @@ internal class DynamicSerializer : BaseSerializer<object?>
                 break;
             case Document doc:
                 SerializeDocumentRefInternal(w, doc.Id, doc.Collection);
+                break;
+            case Query q:
+                _query.Serialize(ctx, w, q);
                 break;
             case NullableDocument<Document> doc:
                 switch (doc)

--- a/Fauna/Serialization/ListSerializer.cs
+++ b/Fauna/Serialization/ListSerializer.cs
@@ -54,9 +54,6 @@ internal class ListSerializer<T> : BaseSerializer<List<T>>
             w.WriteStartArray();
             foreach (object? elem in (IEnumerable)o)
             {
-                if (elem is Query)
-                    throw new ArgumentException("Use QueryArr to wrap a List<Query>");
-
                 _elemSerializer.Serialize(ctx, w, elem);
             }
             w.WriteEndArray();

--- a/Fauna/Serialization/ListSerializer.cs
+++ b/Fauna/Serialization/ListSerializer.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using Fauna.Exceptions;
 using Fauna.Mapping;
+using ArgumentException = System.ArgumentException;
 
 namespace Fauna.Serialization;
 
@@ -53,6 +54,9 @@ internal class ListSerializer<T> : BaseSerializer<List<T>>
             w.WriteStartArray();
             foreach (object? elem in (IEnumerable)o)
             {
+                if (elem is Query)
+                    throw new ArgumentException("Use QueryArr to wrap a List<Query>");
+
                 _elemSerializer.Serialize(ctx, w, elem);
             }
             w.WriteEndArray();

--- a/Fauna/Serialization/QueryArrSerializer.cs
+++ b/Fauna/Serialization/QueryArrSerializer.cs
@@ -19,18 +19,8 @@ internal class QueryArrSerializer : BaseSerializer<QueryArr>
                 writer.WriteStartObject();
                 writer.WriteFieldName("array");
                 writer.WriteStartArray();
-                foreach (object? t in o.Unwrap)
-                {
-                    if (t is IQueryFragment frag)
-                    {
-                        frag.Serialize(context, writer);
-                    }
-                    else
-                    {
-                        var ser = t is not null ? Serializer.Generate(context, t.GetType()) : DynamicSerializer.Singleton;
-                        ser.Serialize(context, writer, t);
-                    }
-                }
+                var ser = Serializer.Generate(context, o.Unwrap.GetType());
+                ser.Serialize(context, writer, o.Unwrap);
                 writer.WriteEndArray();
                 writer.WriteEndObject();
                 break;

--- a/Fauna/Serialization/QueryArrSerializer.cs
+++ b/Fauna/Serialization/QueryArrSerializer.cs
@@ -18,10 +18,8 @@ internal class QueryArrSerializer : BaseSerializer<QueryArr>
             case QueryArr o:
                 writer.WriteStartObject();
                 writer.WriteFieldName("array");
-                writer.WriteStartArray();
                 var ser = Serializer.Generate(context, o.Unwrap.GetType());
                 ser.Serialize(context, writer, o.Unwrap);
-                writer.WriteEndArray();
                 writer.WriteEndObject();
                 break;
             default:

--- a/Fauna/Serialization/QueryArrSerializer.cs
+++ b/Fauna/Serialization/QueryArrSerializer.cs
@@ -1,0 +1,41 @@
+using Fauna.Exceptions;
+using Fauna.Mapping;
+
+namespace Fauna.Serialization;
+
+internal class QueryArrSerializer : BaseSerializer<QueryArr>
+{
+    public override QueryArr Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        throw new NotImplementedException();
+
+    public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? obj)
+    {
+        switch (obj)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case QueryArr o:
+                writer.WriteStartObject();
+                writer.WriteFieldName("array");
+                writer.WriteStartArray();
+                foreach (object? t in o.Unwrap)
+                {
+                    if (t is IQueryFragment frag)
+                    {
+                        frag.Serialize(context, writer);
+                    }
+                    else
+                    {
+                        var ser = t is not null ? Serializer.Generate(context, t.GetType()) : DynamicSerializer.Singleton;
+                        ser.Serialize(context, writer, t);
+                    }
+                }
+                writer.WriteEndArray();
+                writer.WriteEndObject();
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(obj.GetType()));
+        }
+    }
+}

--- a/Fauna/Serialization/QueryExprSerializer.cs
+++ b/Fauna/Serialization/QueryExprSerializer.cs
@@ -1,0 +1,36 @@
+using Fauna.Exceptions;
+using Fauna.Mapping;
+using Fauna.Types;
+
+namespace Fauna.Serialization;
+
+
+internal class QueryExprSerializer : BaseSerializer<QueryExpr>
+{
+    public override QueryExpr Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        throw new NotImplementedException();
+
+    public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? obj)
+    {
+        switch (obj)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case QueryExpr o:
+                writer.WriteStartObject();
+                writer.WriteFieldName("fql");
+                writer.WriteStartArray();
+                foreach (var t in o.Unwrap)
+                {
+                    var ser = Serializer.Generate(context, t.GetType());
+                    ser.Serialize(context, writer, t);
+                }
+                writer.WriteEndArray();
+                writer.WriteEndObject();
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(obj.GetType()));
+        }
+    }
+}

--- a/Fauna/Serialization/QueryLiteralSerializer.cs
+++ b/Fauna/Serialization/QueryLiteralSerializer.cs
@@ -1,0 +1,26 @@
+using Fauna.Exceptions;
+using Fauna.Mapping;
+
+namespace Fauna.Serialization;
+
+
+internal class QueryLiteralSerializer : BaseSerializer<QueryLiteral>
+{
+    public override QueryLiteral Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        throw new NotImplementedException();
+
+    public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? obj)
+    {
+        switch (obj)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case QueryLiteral o:
+                writer.WriteStringValue(o.Unwrap);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(obj.GetType()));
+        }
+    }
+}

--- a/Fauna/Serialization/QueryObjSerializer.cs
+++ b/Fauna/Serialization/QueryObjSerializer.cs
@@ -1,0 +1,30 @@
+using Fauna.Exceptions;
+using Fauna.Mapping;
+
+namespace Fauna.Serialization;
+
+
+internal class QueryObjSerializer : BaseSerializer<QueryObj>
+{
+    public override QueryObj Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        throw new NotImplementedException();
+
+    public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? obj)
+    {
+        switch (obj)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case QueryObj o:
+                writer.WriteStartObject();
+                writer.WriteFieldName("object");
+                var ser = Serializer.Generate(context, o.Unwrap.GetType());
+                ser.Serialize(context, writer, o.Unwrap);
+                writer.WriteEndObject();
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(obj.GetType()));
+        }
+    }
+}

--- a/Fauna/Serialization/QuerySerializer.cs
+++ b/Fauna/Serialization/QuerySerializer.cs
@@ -1,0 +1,26 @@
+using Fauna.Exceptions;
+using Fauna.Mapping;
+
+namespace Fauna.Serialization;
+
+internal class QuerySerializer : BaseSerializer<Query>
+{
+    public override Query Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        throw new NotImplementedException();
+
+    public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? obj)
+    {
+        switch (obj)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case Query o:
+                var ser = Serializer.Generate(context, o.GetType());
+                ser.Serialize(context, writer, o);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(obj.GetType()));
+        }
+    }
+}

--- a/Fauna/Serialization/QueryValSerializer.cs
+++ b/Fauna/Serialization/QueryValSerializer.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics;
+using Fauna.Exceptions;
+using Fauna.Mapping;
+
+namespace Fauna.Serialization;
+
+
+internal class QueryValSerializer : BaseSerializer<QueryObj>
+{
+    public override QueryObj Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        throw new NotImplementedException();
+
+    public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? obj)
+    {
+        switch (obj)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case QueryVal v:
+                writer.WriteStartObject();
+                writer.WriteFieldName("value");
+                var ser = v.Unwrap is not null ? Serializer.Generate(context, v.Unwrap.GetType()) : DynamicSerializer.Singleton;
+                ser.Serialize(context, writer, v.Unwrap);
+                writer.WriteEndObject();
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(obj.GetType()));
+        }
+    }
+}

--- a/Fauna/Serialization/Serializer.cs
+++ b/Fauna/Serialization/Serializer.cs
@@ -47,6 +47,7 @@ public static class Serializer
     private static readonly QueryLiteralSerializer _queryLiteral = new();
     private static readonly QueryArrSerializer _queryArr = new();
     private static readonly QueryObjSerializer _queryObj = new();
+    private static readonly QueryValSerializer _queryVal = new();
 
 
     /// <summary>
@@ -97,6 +98,7 @@ public static class Serializer
         if (targetType == typeof(QueryLiteral)) return _queryLiteral;
         if (targetType == typeof(QueryArr)) return _queryArr;
         if (targetType == typeof(QueryObj)) return _queryObj;
+        if (targetType == typeof(QueryVal)) return _queryVal;
 
         if (targetType.IsGenericType)
         {

--- a/Fauna/Serialization/Serializer.cs
+++ b/Fauna/Serialization/Serializer.cs
@@ -1,5 +1,4 @@
 using Fauna.Mapping;
-using Fauna.Serialization;
 using Fauna.Types;
 using Stream = Fauna.Types.Stream;
 
@@ -43,6 +42,12 @@ public static class Serializer
     private static readonly DocumentSerializer<NamedDocument> _namedDoc = new();
     private static readonly DocumentSerializer<Ref> _docRef = new();
     private static readonly DocumentSerializer<NamedRef> _namedDocRef = new();
+    private static readonly QuerySerializer _query = new();
+    private static readonly QueryExprSerializer _queryExpr = new();
+    private static readonly QueryLiteralSerializer _queryLiteral = new();
+    private static readonly QueryArrSerializer _queryArr = new();
+    private static readonly QueryObjSerializer _queryObj = new();
+
 
     /// <summary>
     /// Generates a serializer for the specified non-nullable .NET type.
@@ -87,6 +92,11 @@ public static class Serializer
         if (targetType == typeof(NamedDocument)) return _namedDoc;
         if (targetType == typeof(Ref)) return _docRef;
         if (targetType == typeof(NamedRef)) return _namedDocRef;
+        if (targetType == typeof(Query)) return _query;
+        if (targetType == typeof(QueryExpr)) return _queryExpr;
+        if (targetType == typeof(QueryLiteral)) return _queryLiteral;
+        if (targetType == typeof(QueryArr)) return _queryArr;
+        if (targetType == typeof(QueryObj)) return _queryObj;
 
         if (targetType.IsGenericType)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description

Add Query fragment serialization to the `Serializer` 

### Motivation and context

- Add support for `QueryArr` and `QueryObj`
- Align serialization with other types

### How was the change tested?

Included Integration tests

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
