### PR TITLE
fix(perf-tests): Concourse envvars don't propagate to subtask like I thought

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -70,6 +70,7 @@ jobs:
           FAUNA_ENDPOINT: https://db.fauna-dev.com
           FAUNA_SECRET: ((dev-driver-perf-test-key))
           FAUNA_ENVIRONMENT: dev
+          CONCOURSE_URL: http://concourse.faunadb.net/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
         on_success:
           put: perf-notify
           params:

--- a/concourse/scripts/perf.sh
+++ b/concourse/scripts/perf.sh
@@ -29,7 +29,7 @@ echo '_(non-query time in milliseconds)_' >> ../slack-message/perf-stats
 echo '```' >> ../slack-message/perf-stats
 cat ./Fauna.Test/bin/Debug/net8.0/stats_$LOG_UNIQUE.txt >> ../slack-message/perf-stats
 echo '```' >> ../slack-message/perf-stats
-echo "_<http://concourse.faunadb.net/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Concourse job>_" > ../slack-message/perf-stats
+echo "_<$CONCOURSE_URL|Concourse job>_" > ../slack-message/perf-stats
 
 # Run teardown.sh to delete the test collections
 pushd Fauna.Test/Performance/setup


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
One more quick pipeline fix - Concourse can be a bit inscrutable.

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
