### PR TITLE
[DOCS-3431] README: Fix Event Streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,11 +289,15 @@ switch (r.Data)
 }
 ```
 
-## Streams
+## Event Streaming
 
-Example of creating a [Stream](https://docs.fauna.com/fauna/current/learn/track-changes/streaming/):
+The driver supports [Event Streaming](https://docs.fauna.com/fauna/current/learn/track-changes/streaming/).
+
+To start and subscribe to an event stream, pass a
+query that produces a stream token to `EventStreamAsync`:
+
 ```csharp
-var stream = await client.StreamQueryAsync<Person>(FQL($"Person.all().toStream"));
+var stream = await client.EventStreamAsync<Person>(FQL($"Person.all().toStream"));
 await foreach (var evt in stream)
 {
     Console.WriteLine($"Received Event Type: {evt.Type}");
@@ -304,4 +308,3 @@ await foreach (var evt in stream)
     }
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ switch (r.Data)
 The driver supports [Event Streaming](https://docs.fauna.com/fauna/current/learn/track-changes/streaming/).
 
 To start and subscribe to an event stream, pass a
-query that produces a stream token to `EventStreamAsync`:
+query that produces a stream token to `EventStreamAsync()`:
 
 ```csharp
 var stream = await client.EventStreamAsync<Person>(FQL($"Person.all().toStream"));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
- Fixes an error in the Event Streaming example (`StreamQueryAsync` should be `EventStreamAsync`).
- Adds a little more context about how to start and subscribe to a stream. 

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
