### PR TITLE
fix(event-streams): CPU Utilization

### DIFF
--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -449,7 +449,7 @@ public class IntegrationTests
             }
         });
 
-        Assert.AreEqual("Invalid request body: invalid stream value provided", ex?.Message);
+        Assert.AreEqual("BadRequest: Bad Request", ex?.Message);
 
         return Task.CompletedTask;
     }

--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -449,7 +449,7 @@ public class IntegrationTests
             }
         });
 
-        Assert.AreEqual("BadRequest: Bad Request", ex?.Message);
+        Assert.AreEqual("Invalid request body: invalid stream value provided", ex?.Message);
 
         return Task.CompletedTask;
     }

--- a/Fauna/Core/Connection.cs
+++ b/Fauna/Core/Connection.cs
@@ -1,10 +1,7 @@
 ﻿using System.Collections.Concurrent;
-using System.Net;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
-using Fauna.Exceptions;
 using Fauna.Mapping;
-using Fauna.Serialization;
 using Fauna.Types;
 using Polly;
 using Stream = System.IO.Stream;
@@ -59,7 +56,7 @@ internal class Connection : IConnection
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            var listener = new EventListener<T>();
+            using var bc = new BlockingCollection<Event<T>>(new ConcurrentQueue<Event<T>>());
             Task<PolicyResult<HttpResponseMessage>> streamTask =
                 _cfg.RetryConfiguration.RetryPolicy.ExecuteAndCaptureAsync(async () =>
                 {
@@ -75,8 +72,7 @@ internal class Connection : IConnection
 
                     if (!response.IsSuccessStatusCode)
                     {
-                        listener.BreakAndClose();
-                        return response;
+                        bc.CompleteAdding();
                     }
 
                     await using var streamAsync = await response.Content.ReadAsStreamAsync(cancellationToken);
@@ -92,80 +88,25 @@ internal class Connection : IConnection
 
                         var evt = Event<T>.From(line, ctx);
                         stream.LastCursor = evt.Cursor;
-                        listener.Dispatch(evt);
+                        bc.Add(evt, cancellationToken);
                     }
 
-                    listener.Close();
                     return response;
                 });
 
-            await foreach (var evt in listener.Events().WithCancellation(cancellationToken))
+            foreach (var evt in bc.GetConsumingEnumerable(cancellationToken))
             {
-                if (evt is null) break;
-
                 yield return evt;
             }
 
             await streamTask;
-            if (streamTask.Result.Result.IsSuccessStatusCode)
+            bc.CompleteAdding();
+            if (streamTask.Result.Outcome == OutcomeType.Successful)
             {
                 continue;
             }
 
-            var httpResponse = streamTask.Result.Result;
-            string body = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
-
-            throw ExceptionHandler.FromRawResponse(body, httpResponse);
-        }
-    }
-
-    /// <summary>
-    /// A helper class for handling events in a thread-safe manner.
-    /// </summary>
-    /// <typeparam name="T">The type of event data.</typeparam>
-    private class EventListener<T> where T : notnull
-    {
-        private readonly ConcurrentQueue<Event<T>?> _queue = new();
-        private readonly SemaphoreSlim _semaphore = new(0);
-        private bool _closed;
-
-        public void Dispatch(Event<T> evt)
-        {
-            _queue.Enqueue(evt);
-            _semaphore.Release();
-        }
-
-        public void BreakAndClose()
-        {
-            _queue.Enqueue(null);
-            _semaphore.Release();
-            Close();
-        }
-
-        public async IAsyncEnumerable<Event<T>?> Events()
-        {
-            while (true)
-            {
-                await _semaphore.WaitAsync();
-
-                if (_closed)
-                {
-                    _semaphore.Release();
-                    yield break;
-                }
-
-                if (_queue.TryDequeue(out var evt))
-                {
-                    yield return evt;
-                }
-
-                _semaphore.Release();
-            }
-        }
-
-        public void Close()
-        {
-            _closed = true;
+            throw streamTask.Result.FinalException;
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
Update `OpenStream` to use a `BlockingCollection`

### Motivation and context
We had a tight loop in the `EventListener` that was causing high CPU utilization

### How was the change tested?

Integration tests and

<details>
<summary>Sandbox app</summary>

```csharp
using Fauna;
using Fauna.Mapping;

var client = new Client(Environment.GetEnvironmentVariable("FAUNA_SECRET")!);
var stream = await client.EventStreamAsync<Product>(Query.FQL($"Product.all().toStream()"));
var listenerLoop = Task.Run(async () =>
{
    while (true)
    {
        Console.WriteLine("Waiting for events...");
        await Task.Delay(TimeSpan.FromSeconds(15));
    }
});

var eventsLoop = Task.Run(async () =>
{
    await foreach (var evt in stream)
    {
        Console.WriteLine($"Received Event Type: {evt.Type}");
        if (evt.Data != null)
        {
            Console.WriteLine($"Data: {evt.Data.Name}");
        }
    }
});

await Task.WhenAny(listenerLoop, eventsLoop);

// ReSharper disable once ClassNeverInstantiated.Global
public class Product
{
    [Id] public string? Id { get; set; }
    
    // ReSharper disable once UnassignedField.Global
    public required string Name;
}

```
</details>


### Screenshots (if appropriate):

Before

![image](https://github.com/user-attachments/assets/36cc4864-8c18-44e3-a5d5-5a14e1a2b279)


After

![image](https://github.com/user-attachments/assets/ba387c98-38b9-4d45-ad82-e7fe0dae3680)


### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
