### PR TITLE
fix(performance): Removing superfluous await based on profiling findings

### DIFF
--- a/Fauna/Core/Connection.cs
+++ b/Fauna/Core/Connection.cs
@@ -35,8 +35,8 @@ internal class Connection : IConnection
         HttpResponseMessage response;
         {
             var policyResult = await _cfg.RetryConfiguration.RetryPolicy
-                .ExecuteAndCaptureAsync(async () =>
-                    await _cfg.HttpClient.SendAsync(CreateHttpRequest(path, body, headers), cancel))
+                .ExecuteAndCaptureAsync(() =>
+                    _cfg.HttpClient.SendAsync(CreateHttpRequest(path, body, headers), cancel))
                 .ConfigureAwait(false);
             response = policyResult.Outcome == OutcomeType.Successful
                 ? policyResult.Result


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
While doing some profiling in Visual Studio (on Windows), I found that we have an extra `async ... await` in this method call since `ExecuteAndCaptureAsync` accepts a `Task<HttpResponseMessage>` which is what is being returned by `HttpClient.SendAsync`.  When I remove the extra `await`, it gives back a little CPU time.  My hypothesis (Lucas agrees) is that wrapping the `SendAsync` call in an `await` probably wraps the returned `Task` in another awaitable thread/Task, so the thread handling in .NET has to await two different Tasks for the one call.

FWIW, I was waiting to commit this until I'd found other fixes via profiling, but nothing else has made much of a splash.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
(covered above)

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran profiling through Visual Studio against a test app that consumed the DLL, as well as ran the Performance tests with and without profiling; all avenues show a small but noticeable improvement.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
