### PR TITLE
chore(perf-tests): Improve perf metrics for paginating queries

### DIFF
--- a/Fauna.Test/Performance/TestDataModels.cs
+++ b/Fauna.Test/Performance/TestDataModels.cs
@@ -1,4 +1,5 @@
 using Fauna.Mapping;
+using Fauna.Types;
 
 namespace Fauna.Test.Performance;
 
@@ -21,6 +22,9 @@ internal class Product
 
     [Field]
     public bool InStock { get; init; } = false;
+
+    [Field]
+    public Ref? Manufacturer { get; init; }
 }
 
 /// <summary>

--- a/Fauna.Test/Performance/setup/queries.json
+++ b/Fauna.Test/Performance/setup/queries.json
@@ -67,7 +67,7 @@
       }
     },
     {
-      "name": "create_many_products_page_results",
+      "name": "create_many_products",
       "parts": [
         "Set.sequence(1,100).toArray().map(x => Product.create({",
         "name: \"New Product #{x}\", ",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
When a perf test is going to paginate, it will now paginate via three different methods: using `client.QueryAsync()` with the `after` token; using `PaginateAsync()`; and using `FlattenAsync()`.  Also, when reporting metrics on the overhead, it will now divide by the number of queries observed in the `StatsCollector` to make comparing the various query perf numbers clearer.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran it a number of times locally; the new output will automatically be picked up and sent to #alerts-driver-perf in Slack.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
