### PR TITLE
feat: Add client method to handle loading a ref

### DIFF
--- a/Fauna.Test/E2E/E2ELinq.Test.cs
+++ b/Fauna.Test/E2E/E2ELinq.Test.cs
@@ -94,4 +94,40 @@ public class E2ELinqTest
         Assert.AreEqual(new Module("E2ELinqTest_Author"), ex.Collection);
         Assert.AreEqual("not found", ex.Cause);
     }
+
+
+    [Test]
+    public async Task E2ELinq_LoadRef()
+    {
+        var res = await s_db.Book
+            .Where(b => b.Name == "War and Peace")
+            .SingleAsync();
+        var author = await s_db.LoadRefAsync(res.Author);
+        Assert.AreEqual("Leo Tolstoy", author.Name);
+    }
+
+
+    [Test]
+    public void E2ELinq_LoadRefThrows()
+    {
+        var col = new Module("E2ELinqTest_Author");
+        var input = new Ref<object>("123", col);
+        var ex = Assert.ThrowsAsync<NullDocumentException>(async () => await s_db.LoadRefAsync(input))!;
+        Assert.AreEqual("123", ex.Id);
+        Assert.AreEqual(col, ex.Collection);
+        Assert.AreEqual("not found", ex.Cause);
+    }
+
+    [Test]
+    public async Task E2ELinq_LoadsLoadedRef()
+    {
+        var res = await s_db.Book
+            .Where(b => b.Name == "War and Peace")
+            .SingleAsync();
+        var author = await s_db.LoadRefAsync(res.Author);
+        var r = new Ref<E2ELinqTestDb.E2ELinqTestAuthor>(res.Author.Id, res.Author.Collection, author);
+        Assert.True(r.IsLoaded);
+        var author2 = await s_db.LoadRefAsync(r);
+        Assert.AreSame(author, author2);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Add IClient.LoadRefAsync<T>(BaseRef<T> reference) method. This will load a ref by querying Fauna, or return the loaded value if it's already present.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
BT-5137

If a user has a reference to a document, allow a low effort way of materializing it.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add e2e tests

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [X] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
