### PR TITLE
fix: dynamic ref deser ends at wrong token

### DIFF
--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -522,4 +522,20 @@ public class IntegrationTests
 
         Assert.Zero(expectedEvents, "stream handler should process all events");
     }
+
+    [Test]
+    public async Task CollectionAll()
+    {
+        var query = FQL($"Collection.all()");
+        object result = (await _client.QueryAsync(query)).Data!;
+        switch (result)
+        {
+            case Page<object> p:
+                Assert.Greater(p.Data.Count, 0);
+                break;
+            default:
+                Assert.Fail($"Expected Page<Ref<Dictionary<string, object>>> but was {result.GetType()}");
+                break;
+        }
+    }
 }

--- a/Fauna/Serialization/DynamicSerializer.cs
+++ b/Fauna/Serialization/DynamicSerializer.cs
@@ -85,6 +85,9 @@ internal class DynamicSerializer : BaseSerializer<object?>
                     builder.Doc = (Dictionary<string, object>?)_dict.DeserializeDocument(context, builder.Id, builder.Name, builder.Collection, ref reader);
                     break;
             }
+
+            // After we deserialize into a doc, we end on the EndDocument a token and do not want to read again
+            if (reader.CurrentTokenType == TokenType.EndDocument) break;
         }
 
         return builder.Build();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
Terminate dynamic ref deserialization on EndDocument token

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
We farm out the doc deserialization and end on an EndDocument token, then advance the token stream before checking if we are at the end of the document.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [X] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
