### PR TITLE
feat(logging): Add support for ILogger-based debug logging, including BYO

### DIFF
--- a/Fauna.Test/Util/Logging.Tests.cs
+++ b/Fauna.Test/Util/Logging.Tests.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using static Fauna.Query;
+
+namespace Fauna.Test.Util;
+
+[TestFixture]
+public class LoggingTests
+{
+    [Test]
+    public async Task ValidateCustomLogger()
+    {
+        var logger = new Mock<ILogger>();
+        logger
+            .Setup(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+            ))
+            .Verifiable();
+
+        var client = new Client(
+            new Configuration("secret", logger: logger.Object)
+            {
+                Endpoint = new Uri("http://localhost:8443")
+            }
+        );
+
+        await client.QueryAsync(FQL($"1+1"));
+
+        logger.Verify(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+            ),
+            Times.AtLeastOnce);
+    }
+}

--- a/Fauna/Configuration.cs
+++ b/Fauna/Configuration.cs
@@ -1,4 +1,6 @@
 ﻿using Fauna.Core;
+using Fauna.Util;
+using Microsoft.Extensions.Logging;
 
 namespace Fauna;
 
@@ -44,28 +46,32 @@ public record class Configuration
     /// </summary>
     public IStatsCollector? StatsCollector { get; init; } = new StatsCollector();
 
-    public Configuration()
-    {
-        if (string.IsNullOrEmpty(Secret))
-        {
-            throw new ArgumentNullException(nameof(Secret), "Need to set FAUNA_SECRET environment variable or pass a secret as a parameter when creating the Client.");
-        }
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="Configuration"/> record with the specified secret key.
     /// </summary>
     /// <param name="secret">The secret key used for authentication.</param>
     /// <param name="httpClient">The <see cref="HttpClient"/> to use.</param>
-    public Configuration(string secret, HttpClient? httpClient = null)
+    public Configuration(string secret = "", HttpClient? httpClient = null, ILogger? logger = null)
     {
-        Secret = secret;
-        if (httpClient is null)
+        if (string.IsNullOrEmpty(secret) && string.IsNullOrEmpty(Secret))
         {
-            return;
+            throw new ArgumentNullException(nameof(Secret), "Need to set FAUNA_SECRET environment variable or pass a secret as a parameter when creating the Client.");
         }
 
-        HttpClient = httpClient;
-        DisposeHttpClient = false;
+        if (!string.IsNullOrEmpty(secret))
+        {
+            Secret = secret;
+        }
+
+        if (httpClient != null)
+        {
+            HttpClient = httpClient;
+            DisposeHttpClient = false;
+        }
+
+        if (logger != null)
+        {
+            Logger.Initialize(logger);
+        }
     }
 }

--- a/Fauna/Core/Connection.cs
+++ b/Fauna/Core/Connection.cs
@@ -152,15 +152,19 @@ internal class Connection : IConnection
                 request.Headers
                     .Select(header =>
                     {
+                        // Redact Auth header in debug logs
                         if (header.Key.StartsWith("Authorization", StringComparison.InvariantCultureIgnoreCase))
                         {
-                            return KeyValuePair.Create(header.Key, new[] { "HIDDEN" }.AsEnumerable());
+                            return KeyValuePair.Create(header.Key, new[] { "hidden" }.AsEnumerable());
                         }
 
                         return header;
                     })
                     .ToDictionary(kv => kv.Key, kv => kv.Value.ToList()))
         );
+
+        // Emit unredacted Auth header in trace logs
+        Logger.Instance.LogTrace("Unredacted Authorization header: {value}", request.Headers.Authorization?.ToString() ?? "null");
 
         return request;
     }

--- a/Fauna/Core/Connection.cs
+++ b/Fauna/Core/Connection.cs
@@ -53,6 +53,8 @@ internal class Connection : IConnection
                 response.Headers.ToDictionary(kv => kv.Key, kv => kv.Value.ToList()))
         );
 
+        Logger.Instance.LogTrace("Response body: {body}", await response.Content.ReadAsStringAsync(cancel));
+
         return response;
     }
 
@@ -163,8 +165,9 @@ internal class Connection : IConnection
                     .ToDictionary(kv => kv.Key, kv => kv.Value.ToList()))
         );
 
-        // Emit unredacted Auth header in trace logs
+        // Emit unredacted Auth header and response body in trace logs
         Logger.Instance.LogTrace("Unredacted Authorization header: {value}", request.Headers.Authorization?.ToString() ?? "null");
+        Logger.Instance.LogTrace("Request body: {body}", request.Content.ReadAsStringAsync().Result);
 
         return request;
     }

--- a/Fauna/Fauna.csproj
+++ b/Fauna/Fauna.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -15,9 +15,11 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageReference Include="Polly" Version="8.3.0" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="dotnet format --severity warn --verbosity diagnostic"/>
+    <Exec Command="dotnet format --severity warn --verbosity diagnostic" />
   </Target>
 </Project>

--- a/Fauna/Util/Logger.cs
+++ b/Fauna/Util/Logger.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Logging;
+
+namespace Fauna.Util;
+
+/// <summary>
+/// This class encapsulates an <see cref="ILogger"/> object for logging throughout
+/// the Fauna .NET driver business logic.
+/// </summary>
+internal static class Logger
+{
+    private static ILogger? s_logger;
+
+    /// <summary>
+    /// The singleton <see cref="ILogger"/> instance to use for logging
+    /// </summary>
+    public static ILogger Instance
+    {
+        get
+        {
+            if (s_logger == null)
+            {
+                s_logger = InitializeDefaultLogger();
+            }
+
+            return s_logger;
+        }
+    }
+
+    /// <summary>
+    /// Optionally initialize the internal <see cref="ILogger"/> with a custom one
+    /// </summary>
+    /// <param name="logger">The <see cref="ILogger"/> instance to use for logging</param>
+    public static void Initialize(ILogger logger)
+    {
+        s_logger = logger;
+    }
+
+    /// <summary>
+    /// Initializes a default Console logger with single-line output, UTC timestamps, and
+    /// minimum log-level based on the FAUNA_DEBUG environment variable; if the variable is
+    /// not set, the default minimum log-level is <see cref="LogLevel.None"/>
+    /// </summary>
+    /// <returns>An instance of <see cref="ILogger"/> created with <see cref="ILoggerFactory"/></returns>
+    /// <exception cref="ArgumentException">Throws if FAUNA_DEBUG is outside of acceptable values</exception>
+    private static ILogger InitializeDefaultLogger()
+    {
+        var logLevel = Environment.GetEnvironmentVariable("FAUNA_DEBUG");
+        var minLogLevel = LogLevel.None;
+
+        if (!string.IsNullOrEmpty(logLevel) && int.TryParse(logLevel, out var level))
+        {
+            if (level < (int)LogLevel.Trace || level > (int)LogLevel.None)
+            {
+                throw new ArgumentException(
+                    $"Invalid FAUNA_DEBUG value of {level}; must be between 0 and 6 inclusive. Set to 0 for highest verbosity, default is 6 (no logging).");
+            }
+
+            minLogLevel = (LogLevel)level;
+        }
+
+        using ILoggerFactory factory = LoggerFactory.Create(builder => builder
+            .AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace)
+            .AddSimpleConsole(options =>
+            {
+                options.IncludeScopes = true;
+                options.SingleLine = true;
+                options.TimestampFormat = "yyyy-MM-ddTHH:mm:ss.fffZ ";
+                options.UseUtcTimestamp = true;
+            })
+            .SetMinimumLevel(minLogLevel));
+
+        return factory.CreateLogger("fauna-dotnet");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ To enable debug logging, set the `FAUNA_DEBUG` environment variable to an intege
 * `0`: `LogLevel.Trace` and higher (all messages)
 * `3`: `LogLevel.Warning` and higher
 
+The driver logs HTTP request and response details, including headers. For security, the `Authorization` header is redacted in debug logs but is visible in trace logs.
+
 > [!NOTE]  
 > As of v1.0.0, the driver only outputs `LogLevel.Debug` messages. Use `0` (Trace) or `1` (Debug) to log these messages.
 

--- a/README.md
+++ b/README.md
@@ -310,21 +310,21 @@ await foreach (var evt in stream)
 }
 ```
 
-## Debug Logging
+## Debug logging
 
-To assist in developing your applications, the driver can be configured to emit additional debug log messages. 
-To enable basic debug logging, you can set the `FAUNA_DEBUG` environment variable to an integer value of the 
-`Microsoft.Extensions.Logging.LogLevel` enum; e.g. to see all additional log messages, pass `FAUNA_DEBUG=0`, 
-which corresponds to `LogLevel.Trace`, whereas if you only want to see `LogLevel.Warning` and higher, set `FAUNA_DEBUG=3`.
+To enable debug logging, set the `FAUNA_DEBUG` environment variable to an integer for the `Microsoft.Extensions.Logging.LogLevel`. For example:
 
-_NB: As of release 1.0.0, the driver only outputs `LogLevel.Debug` messages, so you will need to 
-set the variable to `0 (LogLevel.Trace)` or `1 (LogLevel.Debug)` to see those messages._
+* `0`: `LogLevel.Trace` and higher (all messages)
+* `3`: `LogLevel.Warning` and higher
 
-If you prefer to have more control over the additional logging from the driver, you can bring 
-your own `ILogger` implementation (e.g. Serilog, NLog) and pass it to the `Configuration` class 
-when instantiating a `Client`. Below is a basic example using `Serilog`:
+> [!NOTE]  
+> As of v1.0.0, the driver only outputs `LogLevel.Debug` messages. Use `0` (Trace) or `1` (Debug) to log these messages.
 
-First install the packages:
+For advanced logging, you can use a custom `ILogger` implementation, such as Serilog or NLog. Pass the implementation to the `Configuration` class when instantiating a `Client`.
+
+### Basic example: Serilog
+
+Install the packages:
 ```
 $ dotnet add package Serilog
 $ dotnet add package Serilog.Extensions.Logging
@@ -332,7 +332,7 @@ $ dotnet add package Serilog.Sinks.Console
 $ dotnet add package Serilog.Sinks.File
 ```
 
-Then instantiate the `Log.Logger` and pass it to the `Configuration` object:
+Configure and use the logger:
 ```csharp
 using Fauna;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
BT-5158

This change adds support for additional debug/trace logging in the driver via `Microsoft.Extensions.Logging.ILogger` interface.  Consumers of the driver can set the `FAUNA_DEBUG` environment variable to `0` or `1` (higher is _less_ verbose in .NET log-levels, so 2+ won't output anything at the moment), which will cause the new `Logger` static class to instantiate a default `ILogger` implementation that writes all messages to `stderr` (to avoid polluting `stdout` for consumers).  At present, the driver will output details about the HTTP request and response to/from Fauna with the `Authorization` header value redacted for security reasons.

However, if consumers want to bring their own `ILogger` implementation (i.e. Serilog), they can pass it to the `Configuration` class when creating a `Client` object.  The README has an example.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
The driver should provide additional debugging information when desired to help aid in debugging issues for consumers, as well as giving consumers a way to get debug messages that they can send to Fauna Support if they're experiencing issues.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a test with a `Mock<ILogger>` to make sure we don't break the BYO functionality.  I also manually verified the BYO functionality in a test app using Serilog.

### Output from default logger:
```
2024-10-15T05:17:05.089Z dbug: fauna-dotnet[0] Fauna HTTP POST Request to http://localhost:8443/query/1 (timeout 5000ms), headers: {"Accept":["application/json"],"Accept-Encoding":["gzip"],"Authorization":["HIDDEN"],"X-Format":["tagged"],"X-Driver":["C#"],"X-Last-Txn-Ts":["0"]}
2024-10-15T05:17:05.481Z dbug: fauna-dotnet[0] Fauna HTTP Response OK from http://localhost:8443/query/1, headers: {"x-faunadb-build":["24.09.04-1d6ea0d"],"Connection":["keep-alive"],"traceparent":["00-a2fa6d6be49f51476c8a2db51e5a1871-a0fd66fae7a8db6c-00"]}
```

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
