### PR TITLE
chore(serialization): Improve deserialization errors

### DIFF
--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -538,4 +538,32 @@ public class IntegrationTests
                 break;
         }
     }
+
+    [Test]
+    [Category("serialization")]
+    public void ValidateUnwrappedListOfQueriesError()
+    {
+        var q = new List<Query>
+        {
+            FQL($"4 + 2"),
+            FQL($"5 + 2"),
+            FQL($"6 + 2")
+        };
+        var ex = Assert.ThrowsAsync<SerializationException>(async () => await _client.QueryAsync<List<int>>(FQL($"{q}")));
+        Assert.IsTrue(ex!.Message.StartsWith("Unable to deserialize `FaunaType.Object` with `IntSerializer`"));
+    }
+
+    [Test]
+    [Category("serialization")]
+    public void ValidateUnwrappedMapOfQueriesError()
+    {
+        var q = new Dictionary<string, Query>
+        {
+            { "six", FQL($"4 + 2") },
+            { "seven", FQL($"1 + 6") },
+            { "eight", FQL($"3 + 5") }
+        };
+        var ex = Assert.ThrowsAsync<SerializationException>(async () => await _client.QueryAsync<Dictionary<string, int>>(FQL($"{q}")));
+        Assert.IsTrue(ex!.Message.Contains("Unable to deserialize `FaunaType.Object` with `IntSerializer`"));
+    }
 }

--- a/Fauna.Test/Serialization/Serializers/TypedSerializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializers/TypedSerializer.Tests.cs
@@ -41,7 +41,7 @@ public class TypedSerializerTests
                 else
                 {
                     var ex = Assert.Throws<SerializationException>(() => Helpers.Serialize(t.Serializer, s_ctx, t.Value));
-                    Assert.That(ex!.Message, Is.EqualTo(t.Throws));
+                    Assert.IsTrue(ex!.Message.StartsWith(t.Throws));
                 }
                 break;
 
@@ -54,7 +54,7 @@ public class TypedSerializerTests
                 else
                 {
                     var ex = Assert.Throws<SerializationException>(() => Helpers.Deserialize(t.Serializer, s_ctx, (string)t.Value!));
-                    Assert.That(ex!.Message, Is.EqualTo(t.Throws));
+                    Assert.IsTrue(ex!.Message.StartsWith(t.Throws));
                 }
                 break;
 
@@ -101,7 +101,7 @@ public class TypedSerializerTests
             {
                 Serializer = _string,
                 Value = Helpers.IntMaxWire,
-                Throws = "Unexpected token `Int` deserializing with `StringSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Int` with `StringSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -133,7 +133,7 @@ public class TypedSerializerTests
             {
                 Serializer = _byte,
                 Value = Helpers.LongMaxWire,
-                Throws = "Unexpected token `Long` deserializing with `ByteSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Long` with `ByteSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -165,7 +165,7 @@ public class TypedSerializerTests
             {
                 Serializer = _sbyte,
                 Value = Helpers.LongMaxWire,
-                Throws = "Unexpected token `Long` deserializing with `SByteSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Long` with `SByteSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -207,7 +207,7 @@ public class TypedSerializerTests
             {
                 Serializer = _short,
                 Value = Helpers.LongMaxWire,
-                Throws = "Unexpected token `Long` deserializing with `ShortSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Long` with `ShortSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -249,7 +249,7 @@ public class TypedSerializerTests
             {
                 Serializer = _ushort,
                 Value = Helpers.LongMaxWire,
-                Throws = "Unexpected token `Long` deserializing with `UShortSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Long` with `UShortSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -291,7 +291,7 @@ public class TypedSerializerTests
             {
                 Serializer = _int,
                 Value = Helpers.LongMaxWire,
-                Throws = "Unexpected token `Long` deserializing with `IntSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Long` with `IntSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -333,7 +333,7 @@ public class TypedSerializerTests
             {
                 Serializer = _uint,
                 Value = Helpers.NullWire,
-                Throws = "Unexpected token `Null` deserializing with `UIntSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Null` with `UIntSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -375,7 +375,7 @@ public class TypedSerializerTests
             {
                 Serializer = _long,
                 Value = Helpers.NullWire,
-                Throws = "Unexpected token `Null` deserializing with `LongSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Null` with `LongSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -417,7 +417,7 @@ public class TypedSerializerTests
             {
                 Serializer = _float,
                 Value = Helpers.NullWire,
-                Throws = "Unexpected token `Null` deserializing with `FloatSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Null` with `FloatSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -489,7 +489,7 @@ public class TypedSerializerTests
             {
                 Serializer = _double,
                 Value = Helpers.NullWire,
-                Throws = "Unexpected token `Null` deserializing with `DoubleSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Null` with `DoubleSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -531,7 +531,7 @@ public class TypedSerializerTests
             {
                 Serializer = _bool,
                 Value = Helpers.NullWire,
-                Throws = "Unexpected token `Null` deserializing with `BooleanSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Null` with `BooleanSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -563,7 +563,7 @@ public class TypedSerializerTests
             {
                 Serializer = _date,
                 Value = Helpers.NullWire,
-                Throws = "Unexpected token `Null` deserializing with `DateOnlySerializer`",
+                Throws = "Unable to deserialize `FaunaType.Null` with `DateOnlySerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -595,7 +595,7 @@ public class TypedSerializerTests
             {
                 Serializer = _time,
                 Value = Helpers.NullWire,
-                Throws = "Unexpected token `Null` deserializing with `DateTimeSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Null` with `DateTimeSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },
@@ -627,7 +627,7 @@ public class TypedSerializerTests
             {
                 Serializer = _offset,
                 Value = Helpers.NullWire,
-                Throws = "Unexpected token `Null` deserializing with `DateTimeOffsetSerializer`",
+                Throws = "Unable to deserialize `FaunaType.Null` with `DateTimeOffsetSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },

--- a/Fauna.Test/Serialization/TestClasses.cs
+++ b/Fauna.Test/Serialization/TestClasses.cs
@@ -225,7 +225,7 @@ public class IntToStringSerializer : BaseSerializer<int>
         return reader.CurrentTokenType switch
         {
             TokenType.String => int.Parse(reader.GetString() ?? "0"),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
     }
 

--- a/Fauna/Linq/Deserializers.cs
+++ b/Fauna/Linq/Deserializers.cs
@@ -15,6 +15,8 @@ internal class MappedDeserializer<I, O> : BaseSerializer<O>
         _mapper = mapper;
     }
 
+    public override List<FaunaType> GetSupportedTypes() => _inner.GetSupportedTypes();
+
     public override O Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
         _mapper(_inner.Deserialize(context, ref reader));
 
@@ -32,6 +34,8 @@ internal class ProjectionDeserializer : BaseSerializer<object?[]>
     {
         _fields = fields.ToArray();
     }
+
+    public override List<FaunaType> GetSupportedTypes() => _fields.SelectMany(x => x.GetSupportedTypes()).Distinct().ToList();
 
     public override object?[] Deserialize(MappingContext context, ref Utf8FaunaReader reader)
     {

--- a/Fauna/Serialization/BaseRefSerializer.cs
+++ b/Fauna/Serialization/BaseRefSerializer.cs
@@ -14,6 +14,8 @@ internal class RefSerializer<T> : BaseSerializer<Ref<T>> where T : notnull
         _baseRefSerializer = new BaseRefSerializer<T>(docSerializer);
     }
 
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Null, FaunaType.Ref };
+
     public override Ref<T> Deserialize(MappingContext context, ref Utf8FaunaReader reader)
     {
         return (Ref<T>)_baseRefSerializer.Deserialize(context, ref reader);
@@ -34,6 +36,8 @@ internal class NamedRefSerializer<T> : BaseSerializer<NamedRef<T>> where T : not
         _baseRefSerializer = new BaseRefSerializer<T>(docSerializer);
     }
 
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Null, FaunaType.Ref };
+
     public override NamedRef<T> Deserialize(MappingContext context, ref Utf8FaunaReader reader)
     {
         return (NamedRef<T>)_baseRefSerializer.Deserialize(context, ref reader);
@@ -53,6 +57,8 @@ internal class BaseRefSerializer<T> : BaseSerializer<BaseRef<T>> where T : notnu
     {
         _docSerializer = docSerializer;
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Null, FaunaType.Ref };
 
     public override BaseRef<T> Deserialize(MappingContext context, ref Utf8FaunaReader reader)
     {

--- a/Fauna/Serialization/ClassSerializer.cs
+++ b/Fauna/Serialization/ClassSerializer.cs
@@ -18,6 +18,8 @@ internal class ClassSerializer<T> : BaseSerializer<T>, IPartialDocumentSerialize
         _info = info;
     }
 
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Document, FaunaType.Null, FaunaType.Object, FaunaType.Ref };
+
     public object DeserializeDocument(MappingContext context, string? id, string? name, Module? coll, ref Utf8FaunaReader reader)
     {
         object instance = CreateInstance();

--- a/Fauna/Serialization/DictionarySerializer.cs
+++ b/Fauna/Serialization/DictionarySerializer.cs
@@ -14,6 +14,8 @@ internal class DictionarySerializer<T> : BaseSerializer<Dictionary<string, T>>, 
         _elemSerializer = elemSerializer;
     }
 
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Null, FaunaType.Object };
+
     public override Dictionary<string, T> Deserialize(MappingContext context, ref Utf8FaunaReader reader)
     {
         switch (reader.CurrentTokenType)
@@ -36,6 +38,14 @@ internal class DictionarySerializer<T> : BaseSerializer<Dictionary<string, T>>, 
                 writer.WriteNullValue();
                 break;
             case Dictionary<string, T> d:
+                // Get generic type arg for the value, which should be the 2nd type arg
+                var genType = d.GetType().GenericTypeArguments[1];
+
+                if (genType is not null && genType.GetInterfaces().Contains(typeof(IQueryFragment)))
+                {
+                    //throw new ArgumentException($"{genType} cannot be serialized in a Dictionary<>; try {nameof(QueryObj)} instead.");
+                }
+
                 bool shouldEscape = Serializer.Tags.Overlaps(d.Keys);
                 if (shouldEscape) writer.WriteStartEscapedObject();
                 else writer.WriteStartObject();

--- a/Fauna/Serialization/DictionarySerializer.cs
+++ b/Fauna/Serialization/DictionarySerializer.cs
@@ -38,14 +38,6 @@ internal class DictionarySerializer<T> : BaseSerializer<Dictionary<string, T>>, 
                 writer.WriteNullValue();
                 break;
             case Dictionary<string, T> d:
-                // Get generic type arg for the value, which should be the 2nd type arg
-                var genType = d.GetType().GenericTypeArguments[1];
-
-                if (genType is not null && genType.GetInterfaces().Contains(typeof(IQueryFragment)))
-                {
-                    //throw new ArgumentException($"{genType} cannot be serialized in a Dictionary<>; try {nameof(QueryObj)} instead.");
-                }
-
                 bool shouldEscape = Serializer.Tags.Overlaps(d.Keys);
                 if (shouldEscape) writer.WriteStartEscapedObject();
                 else writer.WriteStartObject();

--- a/Fauna/Serialization/DynamicSerializer.cs
+++ b/Fauna/Serialization/DynamicSerializer.cs
@@ -22,6 +22,25 @@ internal class DynamicSerializer : BaseSerializer<object?>
         _docref = new BaseRefSerializer<Dictionary<string, object>>(_dict);
     }
 
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> {
+        FaunaType.Array,
+        FaunaType.Boolean,
+        FaunaType.Bytes,
+        FaunaType.Date,
+        FaunaType.Double,
+        FaunaType.Document,
+        FaunaType.Int,
+        FaunaType.Long,
+        FaunaType.Module,
+        FaunaType.Null,
+        FaunaType.Object,
+        FaunaType.Ref,
+        FaunaType.Set,
+        FaunaType.Stream,
+        FaunaType.String,
+        FaunaType.Time
+    };
+
     public override object? Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
         reader.CurrentTokenType switch
         {

--- a/Fauna/Serialization/FaunaType.cs
+++ b/Fauna/Serialization/FaunaType.cs
@@ -1,0 +1,21 @@
+namespace Fauna.Serialization;
+
+public enum FaunaType
+{
+    Int,
+    Long,
+    Double,
+    String,
+    Date,
+    Time,
+    Boolean,
+    Object,
+    Ref,
+    Document,
+    Array,
+    Bytes,
+    Null,
+    Stream,
+    Module,
+    Set
+}

--- a/Fauna/Serialization/ISerializer.cs
+++ b/Fauna/Serialization/ISerializer.cs
@@ -12,10 +12,12 @@ public interface ISerializer
 {
     object? Deserialize(MappingContext context, ref Utf8FaunaReader reader);
     void Serialize(MappingContext ctx, Utf8FaunaWriter w, object? o);
+    List<FaunaType> GetSupportedTypes();
 }
 
 public abstract class BaseSerializer<T> : ISerializer<T>
 {
+    public virtual List<FaunaType> GetSupportedTypes() => new List<FaunaType>();
 
     protected static TokenType EndTokenFor(TokenType start)
     {
@@ -33,6 +35,10 @@ public abstract class BaseSerializer<T> : ISerializer<T>
     protected string UnexpectedTokenExceptionMessage(TokenType token) => $"Unexpected token `{token}` deserializing with `{GetType().Name}`";
 
     protected string UnsupportedSerializationTypeMessage(Type type) => $"Cannot serialize `{type}` with `{GetType()}`";
+
+    protected string UnexpectedTypeDecodingMessage(FaunaType faunaType) =>
+        $"Unable to deserialize `{faunaType.GetType().Name}.{faunaType}` with `{GetType().Name}`. " +
+        $"Supported types are [{string.Join(", ", GetSupportedTypes().Select(x => $"{x.GetType().Name}.{x}"))}]";
 
     object? ISerializer.Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
         Deserialize(context, ref reader);

--- a/Fauna/Serialization/ListSerializer.cs
+++ b/Fauna/Serialization/ListSerializer.cs
@@ -53,13 +53,6 @@ internal class ListSerializer<T> : BaseSerializer<List<T>>
             o.GetType().GetGenericTypeDefinition() == typeof(List<>) ||
             o.GetType().GetGenericTypeDefinition() == typeof(IEnumerable))
         {
-            var genType = o.GetType().GenericTypeArguments.SingleOrDefault();
-
-            if (genType is not null && genType.GetInterfaces().Contains(typeof(IQueryFragment)))
-            {
-                //throw new ArgumentException($"{genType} cannot be serialized in a List<>; try {nameof(QueryArr)} instead.");
-            }
-
             w.WriteStartArray();
             foreach (object? elem in (IEnumerable)o)
             {

--- a/Fauna/Serialization/ListSerializer.cs
+++ b/Fauna/Serialization/ListSerializer.cs
@@ -14,6 +14,8 @@ internal class ListSerializer<T> : BaseSerializer<List<T>>
         _elemSerializer = elemSerializer;
     }
 
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Array, FaunaType.Null };
+
     public override List<T> Deserialize(MappingContext context, ref Utf8FaunaReader reader)
     {
         if (reader.CurrentTokenType == TokenType.StartPage)
@@ -51,6 +53,13 @@ internal class ListSerializer<T> : BaseSerializer<List<T>>
             o.GetType().GetGenericTypeDefinition() == typeof(List<>) ||
             o.GetType().GetGenericTypeDefinition() == typeof(IEnumerable))
         {
+            var genType = o.GetType().GenericTypeArguments.SingleOrDefault();
+
+            if (genType is not null && genType.GetInterfaces().Contains(typeof(IQueryFragment)))
+            {
+                //throw new ArgumentException($"{genType} cannot be serialized in a List<>; try {nameof(QueryArr)} instead.");
+            }
+
             w.WriteStartArray();
             foreach (object? elem in (IEnumerable)o)
             {

--- a/Fauna/Serialization/ModuleSerializer.cs
+++ b/Fauna/Serialization/ModuleSerializer.cs
@@ -7,6 +7,8 @@ namespace Fauna.Serialization;
 
 internal class ModuleSerializer : BaseSerializer<Module>
 {
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Module, FaunaType.Null };
+
     public override Module Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
         reader.CurrentTokenType switch
         {

--- a/Fauna/Serialization/NullableSerializer.cs
+++ b/Fauna/Serialization/NullableSerializer.cs
@@ -11,6 +11,8 @@ internal class NullableSerializer<T> : BaseSerializer<T?>
         _inner = inner;
     }
 
+    public override List<FaunaType> GetSupportedTypes() => _inner.GetSupportedTypes();
+
     public override T? Deserialize(MappingContext context, ref Utf8FaunaReader reader)
     {
         if (reader.CurrentTokenType == TokenType.Null)

--- a/Fauna/Serialization/NullableStructSerializer.cs
+++ b/Fauna/Serialization/NullableStructSerializer.cs
@@ -11,6 +11,8 @@ internal class NullableStructSerializer<T> : BaseSerializer<T?> where T : struct
         _inner = inner;
     }
 
+    public override List<FaunaType> GetSupportedTypes() => _inner.GetSupportedTypes();
+
     public override T? Deserialize(MappingContext context, ref Utf8FaunaReader reader)
     {
         return reader.CurrentTokenType == TokenType.Null ? new T?() : _inner.Deserialize(context, ref reader);

--- a/Fauna/Serialization/PageSerializer.cs
+++ b/Fauna/Serialization/PageSerializer.cs
@@ -13,6 +13,8 @@ internal class PageSerializer<T> : BaseSerializer<Page<T>>
         _dataSerializer = new ListSerializer<T>(elemSerializer);
     }
 
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Null, FaunaType.Set };
+
     public override Page<T> Deserialize(MappingContext context, ref Utf8FaunaReader reader)
     {
         var wrapInPage = false;

--- a/Fauna/Serialization/Serializer.cs
+++ b/Fauna/Serialization/Serializer.cs
@@ -102,18 +102,9 @@ public static class Serializer
 
         if (targetType.IsGenericType)
         {
-            var args = targetType.GetGenericArguments();
-            var blocked = args.Where(arg => arg.GetInterfaces().Contains(typeof(IQueryFragment)));
-
-            if (blocked.Any())
-            {
-                // throw new ArgumentException(
-                //     $"Query types ({string.Join(", ", blocked.Select(x => x.FullName))}) are not supported as " +
-                //     $"generic type arguments; use {nameof(QueryArr)} or {nameof(QueryObj)} when composing complex queries.");
-            }
-
             if (targetType.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
+                var args = targetType.GetGenericArguments();
                 if (args.Length == 1)
                 {
                     var inner = (ISerializer)Generate(context, args[0]);
@@ -126,10 +117,12 @@ public static class Serializer
                 throw new ArgumentException($"Unsupported nullable type. Generic arguments > 1: {args}");
             }
 
+
             if (targetType.GetGenericTypeDefinition() == typeof(Dictionary<,>))
             {
-                var keyType = args[0];
-                var valueType = args[1];
+                var argTypes = targetType.GetGenericArguments();
+                var keyType = argTypes[0];
+                var valueType = argTypes[1];
 
                 if (keyType != typeof(string))
                     throw new ArgumentException(
@@ -145,7 +138,7 @@ public static class Serializer
 
             if (targetType.GetGenericTypeDefinition() == typeof(List<>) || targetType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
             {
-                var elemType = args[0];
+                var elemType = targetType.GetGenericArguments()[0];
                 var elemSerializer = Generate(context, elemType);
 
                 var serType = typeof(ListSerializer<>).MakeGenericType(new[] { elemType });
@@ -156,7 +149,7 @@ public static class Serializer
 
             if (targetType.GetGenericTypeDefinition() == typeof(Page<>))
             {
-                var elemType = args[0];
+                var elemType = targetType.GetGenericArguments()[0];
                 var elemSerializer = Generate(context, elemType);
 
                 var serType = typeof(PageSerializer<>).MakeGenericType(new[] { elemType });
@@ -167,7 +160,7 @@ public static class Serializer
 
             if (targetType.GetGenericTypeDefinition() == typeof(BaseRef<>))
             {
-                var docType = args[0];
+                var docType = targetType.GetGenericArguments()[0];
                 var docSerializer = Generate(context, docType);
 
                 var serType = typeof(BaseRefSerializer<>).MakeGenericType(new[] { docType });
@@ -178,7 +171,7 @@ public static class Serializer
 
             if (targetType.GetGenericTypeDefinition() == typeof(Ref<>))
             {
-                var docType = args[0];
+                var docType = targetType.GetGenericArguments()[0];
                 var docSerializer = Generate(context, docType);
 
                 var serType = typeof(RefSerializer<>).MakeGenericType(new[] { docType });
@@ -189,7 +182,7 @@ public static class Serializer
 
             if (targetType.GetGenericTypeDefinition() == typeof(NamedRef<>))
             {
-                var docType = args[0];
+                var docType = targetType.GetGenericArguments()[0];
                 var docSerializer = Generate(context, docType);
 
                 var serType = typeof(NamedRefSerializer<>).MakeGenericType(new[] { docType });

--- a/Fauna/Serialization/StreamSerializer.cs
+++ b/Fauna/Serialization/StreamSerializer.cs
@@ -6,6 +6,8 @@ namespace Fauna.Serialization;
 
 internal class StreamSerializer : BaseSerializer<Stream>
 {
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Null, FaunaType.Stream };
+
     public override Stream Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
         reader.CurrentTokenType switch
         {

--- a/Fauna/Serialization/StructSerializers.cs
+++ b/Fauna/Serialization/StructSerializers.cs
@@ -11,7 +11,7 @@ internal class StringSerializer : BaseSerializer<string?>
         {
             TokenType.Null => null,
             TokenType.String => reader.GetString(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -28,6 +28,8 @@ internal class StringSerializer : BaseSerializer<string?>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Null, FaunaType.String };
 }
 
 internal class ByteSerializer : BaseSerializer<byte>
@@ -36,7 +38,7 @@ internal class ByteSerializer : BaseSerializer<byte>
         reader.CurrentTokenType switch
         {
             TokenType.Int => reader.GetByte(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -53,6 +55,8 @@ internal class ByteSerializer : BaseSerializer<byte>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Int, FaunaType.Null };
 }
 
 internal class SByteSerializer : BaseSerializer<sbyte>
@@ -61,7 +65,7 @@ internal class SByteSerializer : BaseSerializer<sbyte>
         reader.CurrentTokenType switch
         {
             TokenType.Int => reader.GetUnsignedByte(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -78,6 +82,8 @@ internal class SByteSerializer : BaseSerializer<sbyte>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Int, FaunaType.Null };
 }
 
 
@@ -87,7 +93,7 @@ internal class ShortSerializer : BaseSerializer<short>
         reader.CurrentTokenType switch
         {
             TokenType.Int => reader.GetShort(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -104,6 +110,8 @@ internal class ShortSerializer : BaseSerializer<short>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Int, FaunaType.Null };
 }
 
 internal class UShortSerializer : BaseSerializer<ushort>
@@ -112,7 +120,7 @@ internal class UShortSerializer : BaseSerializer<ushort>
         reader.CurrentTokenType switch
         {
             TokenType.Int => reader.GetUnsignedShort(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -129,6 +137,8 @@ internal class UShortSerializer : BaseSerializer<ushort>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Int, FaunaType.Null };
 }
 
 internal class IntSerializer : BaseSerializer<int>
@@ -137,7 +147,7 @@ internal class IntSerializer : BaseSerializer<int>
         reader.CurrentTokenType switch
         {
             TokenType.Int => reader.GetInt(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -154,6 +164,8 @@ internal class IntSerializer : BaseSerializer<int>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Int, FaunaType.Null };
 }
 
 internal class UIntSerializer : BaseSerializer<uint>
@@ -162,7 +174,7 @@ internal class UIntSerializer : BaseSerializer<uint>
         reader.CurrentTokenType switch
         {
             TokenType.Int or TokenType.Long => reader.GetUnsignedInt(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -179,6 +191,8 @@ internal class UIntSerializer : BaseSerializer<uint>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Int, FaunaType.Long, FaunaType.Null };
 }
 
 internal class LongSerializer : BaseSerializer<long>
@@ -187,7 +201,7 @@ internal class LongSerializer : BaseSerializer<long>
         reader.CurrentTokenType switch
         {
             TokenType.Int or TokenType.Long => reader.GetLong(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -204,6 +218,8 @@ internal class LongSerializer : BaseSerializer<long>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Int, FaunaType.Long, FaunaType.Null };
 }
 
 internal class FloatSerializer : BaseSerializer<float>
@@ -212,7 +228,7 @@ internal class FloatSerializer : BaseSerializer<float>
         reader.CurrentTokenType switch
         {
             TokenType.Int or TokenType.Long or TokenType.Double => reader.GetFloat(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -229,6 +245,9 @@ internal class FloatSerializer : BaseSerializer<float>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Double, FaunaType.Int, FaunaType.Long, FaunaType.Null };
 }
 
 internal class DoubleSerializer : BaseSerializer<double>
@@ -237,7 +256,7 @@ internal class DoubleSerializer : BaseSerializer<double>
         reader.CurrentTokenType switch
         {
             TokenType.Int or TokenType.Long or TokenType.Double => reader.GetDouble(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -254,6 +273,8 @@ internal class DoubleSerializer : BaseSerializer<double>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Double, FaunaType.Int, FaunaType.Long, FaunaType.Null };
 }
 
 internal class BooleanSerializer : BaseSerializer<bool>
@@ -262,7 +283,7 @@ internal class BooleanSerializer : BaseSerializer<bool>
         reader.CurrentTokenType switch
         {
             TokenType.True or TokenType.False => reader.GetBoolean(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -279,6 +300,8 @@ internal class BooleanSerializer : BaseSerializer<bool>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Boolean, FaunaType.Null };
 }
 
 internal class DateOnlySerializer : BaseSerializer<DateOnly>
@@ -287,7 +310,7 @@ internal class DateOnlySerializer : BaseSerializer<DateOnly>
         reader.CurrentTokenType switch
         {
             TokenType.Date => reader.GetDate(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -304,6 +327,8 @@ internal class DateOnlySerializer : BaseSerializer<DateOnly>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Date, FaunaType.Null };
 }
 
 internal class DateTimeSerializer : BaseSerializer<DateTime>
@@ -312,7 +337,7 @@ internal class DateTimeSerializer : BaseSerializer<DateTime>
         reader.CurrentTokenType switch
         {
             TokenType.Time => reader.GetTime(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -329,6 +354,8 @@ internal class DateTimeSerializer : BaseSerializer<DateTime>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Null, FaunaType.Time };
 }
 
 internal class DateTimeOffsetSerializer : BaseSerializer<DateTimeOffset>
@@ -337,7 +364,7 @@ internal class DateTimeOffsetSerializer : BaseSerializer<DateTimeOffset>
         reader.CurrentTokenType switch
         {
             TokenType.Time => reader.GetTime(),
-            _ => throw new SerializationException(UnexpectedTokenExceptionMessage(reader.CurrentTokenType))
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
         };
 
     public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
@@ -354,4 +381,6 @@ internal class DateTimeOffsetSerializer : BaseSerializer<DateTimeOffset>
                 throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
         }
     }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Null, FaunaType.Time };
 }

--- a/Fauna/Serialization/TokenType.cs
+++ b/Fauna/Serialization/TokenType.cs
@@ -5,7 +5,6 @@ namespace Fauna.Serialization;
 /// </summary>
 public enum TokenType
 {
-
     /// <summary>There is no value. This is the default token type if no data has been read by the <see cref="T:Fauna.Serialization.Utf8FaunaReader" />.</summary>
     None,
 
@@ -65,4 +64,60 @@ public enum TokenType
 
     /// <summary>The token type is the Fauna stream token.</summary>
     Stream,
+}
+
+public static class TokenTypeExtensions
+{
+    public static FaunaType GetFaunaType(this TokenType tokenType)
+    {
+        switch (tokenType)
+        {
+            case TokenType.StartObject:
+            case TokenType.EndObject:
+                return FaunaType.Object;
+
+            case TokenType.StartArray:
+            case TokenType.EndArray:
+                return FaunaType.Array;
+
+            case TokenType.StartPage:
+            case TokenType.EndPage:
+                return FaunaType.Set;
+
+            case TokenType.StartRef:
+            case TokenType.EndRef:
+                return FaunaType.Ref;
+
+            case TokenType.StartDocument:
+            case TokenType.EndDocument:
+                return FaunaType.Document;
+
+            case TokenType.String:
+                return FaunaType.String;
+            // BUGBUG: @bytes support is missing; BT-5183
+            // case TokenType.Bytes:
+            //     return FaunaType.Bytes;
+            case TokenType.Int:
+                return FaunaType.Int;
+            case TokenType.Long:
+                return FaunaType.Long;
+            case TokenType.Double:
+                return FaunaType.Double;
+            case TokenType.Date:
+                return FaunaType.Date;
+            case TokenType.Time:
+                return FaunaType.Time;
+            case TokenType.True:
+            case TokenType.False:
+                return FaunaType.Boolean;
+            case TokenType.Null:
+                return FaunaType.Null;
+            case TokenType.Stream:
+                return FaunaType.Stream;
+            case TokenType.Module:
+                return FaunaType.Module;
+            default:
+                throw new ArgumentException($"No associated FaunaType for TokenType: {tokenType}");
+        }
+    }
 }

--- a/Fauna/Serialization/TokenType.cs
+++ b/Fauna/Serialization/TokenType.cs
@@ -94,7 +94,7 @@ public static class TokenTypeExtensions
 
             case TokenType.String:
                 return FaunaType.String;
-            // BUGBUG: @bytes support is missing; BT-5183
+            // BUG: @bytes support is missing; BT-5183
             // case TokenType.Bytes:
             //     return FaunaType.Bytes;
             case TokenType.Int:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
BT-5115

Pursuant to the ticket, we want to make deserialization errors easier to reason about; the current changes are based on a similar fix in the `fauna-jvm` driver here: https://github.com/fauna/fauna-jvm/pull/129

The change ultimately is an improvement on the `SerializationException` message to avoid spitting out the unexpected token received on the wire from Fauna and instead mapping that token to the expected `FaunaType` (a new enum) that should help point consumers to the issue in their logic where they are expecting to deserialize as one type but the .NET driver's serialization logic saw a different type.  Tests have been updated and a couple new ones were added.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
See above.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I used new test automation to repeatedly validate the changes with various tweaks until I liked the final product.  I also updated the existing serialization automation with the new exception messaging and everything is green.

(I also made heavy use of the new debug logging that I just merged. 😄 )

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
