### PR TITLE
feat(serialization): Add support for @bytes tag

### DIFF
--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Fauna.Exceptions;
 using Fauna.Mapping;
 using Fauna.Types;
@@ -565,5 +566,16 @@ public class IntegrationTests
         };
         var ex = Assert.ThrowsAsync<SerializationException>(async () => await _client.QueryAsync<Dictionary<string, int>>(FQL($"{q}")));
         Assert.IsTrue(ex!.Message.Contains("Unable to deserialize `FaunaType.Object` with `IntSerializer`"));
+    }
+
+    [Test]
+    [Category("serialization")]
+    public async Task ValidateBytesAcrossTheWire()
+    {
+        byte[] byteArray = { 70, 97, 117, 110, 97 };
+
+        var result = await _client.QueryAsync<byte[]>(FQL($"let x:Bytes = {byteArray}; x"));
+
+        Assert.AreEqual(Encoding.UTF8.GetBytes("Fauna"), result.Data);
     }
 }

--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -573,9 +573,10 @@ public class IntegrationTests
     public async Task ValidateBytesAcrossTheWire()
     {
         byte[] byteArray = { 70, 97, 117, 110, 97 };
+        byte[]? nullArray = null;
 
-        var result = await _client.QueryAsync<byte[]>(FQL($"let x:Bytes = {byteArray}; x"));
+        var result = await _client.QueryAsync<List<object?>>(FQL($"let x:Bytes = {byteArray}; let y:Bytes|Null = {nullArray}; [x,y]"));
 
-        Assert.AreEqual(Encoding.UTF8.GetBytes("Fauna"), result.Data);
+        Assert.AreEqual(new[] { Encoding.UTF8.GetBytes("Fauna"), null }, result.Data);
     }
 }

--- a/Fauna.Test/Serialization/Helpers.cs
+++ b/Fauna.Test/Serialization/Helpers.cs
@@ -15,6 +15,9 @@ public class Helpers
     public const byte ByteVal = 42;
     public const sbyte SByteVal = 42;
 
+    public static readonly byte[] BytesVal = { 70, 97, 117, 110, 97 }; // Encoding.UTF8.GetBytes("Fauna")
+    public const string BytesWire = @"{""@bytes"":""RmF1bmE=""}";
+
     public const string ShortMaxWire = @"{""@int"":""32767""}";
     public const string ShortMinWire = @"{""@int"":""-32768""}";
     public const string UShortMaxWire = @"{""@int"":""65535""}";

--- a/Fauna.Test/Serialization/Serializers/TypedSerializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializers/TypedSerializer.Tests.cs
@@ -12,6 +12,7 @@ public class TypedSerializerTests
     private static readonly MappingContext s_ctx = new();
     private static readonly StringSerializer _string = new();
     private static readonly ByteSerializer _byte = new();
+    private static readonly BytesSerializer _bytes = new();
     private static readonly SByteSerializer _sbyte = new();
     private static readonly ShortSerializer _short = new();
     private static readonly UShortSerializer _ushort = new();
@@ -134,6 +135,38 @@ public class TypedSerializerTests
                 Serializer = _byte,
                 Value = Helpers.LongMaxWire,
                 Throws = "Unable to deserialize `FaunaType.Long` with `ByteSerializer`",
+                TestType = Helpers.TestType.Deserialize
+            }
+        },
+
+        // BytesSerializer
+        new object[]
+        {
+            new Helpers.SerializeTest<byte[]>
+            {
+                Serializer = _bytes,
+                Value = Helpers.BytesVal,
+                Expected = Helpers.BytesWire,
+                TestType = Helpers.TestType.Roundtrip
+            }
+        },
+        new object[]
+        {
+            new Helpers.SerializeTest<byte[]>
+            {
+                Serializer = _bytes,
+                Value = null,
+                Expected = Helpers.NullWire,
+                TestType = Helpers.TestType.Serialize
+            }
+        },
+        new object[]
+        {
+            new Helpers.SerializeTest<byte[]>
+            {
+                Serializer = _bytes,
+                Value = Helpers.LongMaxWire,
+                Throws = "Unable to deserialize `FaunaType.Long` with `BytesSerializer`",
                 TestType = Helpers.TestType.Deserialize
             }
         },

--- a/Fauna.Test/Serialization/Utf8FaunaReader.Tests.cs
+++ b/Fauna.Test/Serialization/Utf8FaunaReader.Tests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Fauna.Exceptions;
 using Fauna.Serialization;
 using Fauna.Types;
@@ -50,6 +51,9 @@ public class Utf8FaunaReaderTests
                     break;
                 case TokenType.Module:
                     Assert.AreEqual(obj, reader.GetModule());
+                    break;
+                case TokenType.Bytes:
+                    Assert.AreEqual(obj, reader.GetBytes());
                     break;
                 default:
                     Assert.Null(obj);
@@ -117,6 +121,19 @@ public class Utf8FaunaReaderTests
         var expectedTokens = new List<Tuple<TokenType, object?>>()
         {
             new(TokenType.Int, 123)
+        };
+
+        AssertReader(reader, expectedTokens);
+    }
+
+    [Test]
+    public void ReadBytes()
+    {
+        const string s = @"{""@bytes"": ""RmF1bmE=""}";
+        var reader = new Utf8FaunaReader(s);
+        var expectedTokens = new List<Tuple<TokenType, object?>>()
+        {
+            new(TokenType.Bytes, Encoding.UTF8.GetBytes("Fauna"))
         };
 
         AssertReader(reader, expectedTokens);

--- a/Fauna.Test/Serialization/Utf8FaunaWriter.Tests.cs
+++ b/Fauna.Test/Serialization/Utf8FaunaWriter.Tests.cs
@@ -101,6 +101,13 @@ public class Utf8FaunaWriterTests
     }
 
     [Test]
+    public void WriteBytesValue()
+    {
+        _writer.WriteBytesValue(Encoding.UTF8.GetBytes("Fauna"));
+        AssertWriter(@"{""@bytes"":""RmF1bmE=""}");
+    }
+
+    [Test]
     public void WriteObject()
     {
         _writer.WriteStartObject();
@@ -110,6 +117,7 @@ public class Utf8FaunaWriterTests
         _writer.WriteDouble("aDecimal", 3.14M);
         _writer.WriteBoolean("true", true);
         _writer.WriteBoolean("false", false);
+        _writer.WriteBytes("someBytes", Encoding.UTF8.GetBytes("Fauna"));
         _writer.WriteString("foo", "bar");
         _writer.WriteDate("aDate", new DateTime(2023, 12, 4));
         _writer.WriteTime("aTime", new DateTime(2023, 12, 4, 0, 0, 0, 0, DateTimeKind.Utc));
@@ -121,7 +129,7 @@ public class Utf8FaunaWriterTests
         _writer.WriteStartObject();
         _writer.WriteEndObject();
         _writer.WriteEndObject();
-        AssertWriter(@"{""anInt"":{""@int"":""42""},""aLong"":{""@long"":""42""},""aDouble"":{""@double"":""1.2""},""aDecimal"":{""@double"":""3.14""},""true"":true,""false"":false,""foo"":""bar"",""aDate"":{""@date"":""2023-12-04""},""aTime"":{""@time"":""2023-12-04T00:00:00.0000000Z""},""aNull"":null,""anArray"":[],""anObject"":{}}");
+        AssertWriter(@"{""anInt"":{""@int"":""42""},""aLong"":{""@long"":""42""},""aDouble"":{""@double"":""1.2""},""aDecimal"":{""@double"":""3.14""},""true"":true,""false"":false,""someBytes"":{""@bytes"":""RmF1bmE=""},""foo"":""bar"",""aDate"":{""@date"":""2023-12-04""},""aTime"":{""@time"":""2023-12-04T00:00:00.0000000Z""},""aNull"":null,""anArray"":[],""anObject"":{}}");
     }
 
     [Test]
@@ -134,6 +142,7 @@ public class Utf8FaunaWriterTests
         _writer.WriteDoubleValue(3.14M);
         _writer.WriteBooleanValue(true);
         _writer.WriteBooleanValue(false);
+        _writer.WriteBytesValue(Encoding.UTF8.GetBytes("Fauna"));
         _writer.WriteStringValue("bar");
         _writer.WriteDateValue(new DateTime(2023, 12, 4));
         _writer.WriteTimeValue(new DateTime(2023, 12, 4, 0, 0, 0, 0, DateTimeKind.Utc));
@@ -143,7 +152,7 @@ public class Utf8FaunaWriterTests
         _writer.WriteStartObject();
         _writer.WriteEndObject();
         _writer.WriteEndArray();
-        AssertWriter(@"[{""@int"":""42""},{""@long"":""42""},{""@double"":""1.2""},{""@double"":""3.14""},true,false,""bar"",{""@date"":""2023-12-04""},{""@time"":""2023-12-04T00:00:00.0000000Z""},null,[],{}]");
+        AssertWriter(@"[{""@int"":""42""},{""@long"":""42""},{""@double"":""1.2""},{""@double"":""3.14""},true,false,{""@bytes"":""RmF1bmE=""},""bar"",{""@date"":""2023-12-04""},{""@time"":""2023-12-04T00:00:00.0000000Z""},null,[],{}]");
     }
 
     [Test]

--- a/Fauna/Serialization/DynamicSerializer.cs
+++ b/Fauna/Serialization/DynamicSerializer.cs
@@ -57,6 +57,7 @@ internal class DynamicSerializer : BaseSerializer<object?>
             TokenType.Time => reader.GetTime(),
             TokenType.True or TokenType.False => reader.GetBoolean(),
             TokenType.Module => reader.GetModule(),
+            TokenType.Bytes => reader.GetBytes(),
             TokenType.Null => null,
             _ => throw new SerializationException(
                 $"Unexpected token while deserializing: {reader.CurrentTokenType}"),

--- a/Fauna/Serialization/Serializer.cs
+++ b/Fauna/Serialization/Serializer.cs
@@ -19,12 +19,13 @@ public static class Serializer
 
     internal static readonly HashSet<string> Tags = new()
     {
-        "@int", "@long", "@double", "@date", "@time", "@mod", "@stream", "@ref", "@doc", "@set", "@object"
+        "@int", "@long", "@double", "@date", "@time", "@mod", "@stream", "@ref", "@doc", "@set", "@object", "@bytes"
     };
 
     private static readonly DynamicSerializer s_object = DynamicSerializer.Singleton;
     private static readonly StringSerializer s_string = new();
     private static readonly ByteSerializer s_byte = new();
+    private static readonly BytesSerializer s_bytes = new();
     private static readonly SByteSerializer s_sbyte = new();
     private static readonly ShortSerializer s_short = new();
     private static readonly UShortSerializer s_ushort = new();
@@ -79,6 +80,7 @@ public static class Serializer
         if (targetType == typeof(object)) return s_object;
         if (targetType == typeof(string)) return s_string;
         if (targetType == typeof(byte)) return s_byte;
+        if (targetType == typeof(byte[])) return s_bytes;
         if (targetType == typeof(sbyte)) return s_sbyte;
         if (targetType == typeof(short)) return s_short;
         if (targetType == typeof(ushort)) return s_ushort;

--- a/Fauna/Serialization/StructSerializers.cs
+++ b/Fauna/Serialization/StructSerializers.cs
@@ -59,6 +59,33 @@ internal class ByteSerializer : BaseSerializer<byte>
     public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Int, FaunaType.Null };
 }
 
+internal class BytesSerializer : BaseSerializer<byte[]>
+{
+    public override byte[] Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>
+        reader.CurrentTokenType switch
+        {
+            TokenType.Bytes => reader.GetBytes(),
+            _ => throw new SerializationException(UnexpectedTypeDecodingMessage(reader.CurrentTokenType.GetFaunaType()))
+        };
+
+    public override void Serialize(MappingContext context, Utf8FaunaWriter writer, object? o)
+    {
+        switch (o)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case byte[] b:
+                writer.WriteBytesValue(b);
+                break;
+            default:
+                throw new SerializationException(UnsupportedSerializationTypeMessage(o.GetType()));
+        }
+    }
+
+    public override List<FaunaType> GetSupportedTypes() => new List<FaunaType> { FaunaType.Bytes, FaunaType.Null };
+}
+
 internal class SByteSerializer : BaseSerializer<sbyte>
 {
     public override sbyte Deserialize(MappingContext context, ref Utf8FaunaReader reader) =>

--- a/Fauna/Serialization/TokenType.cs
+++ b/Fauna/Serialization/TokenType.cs
@@ -38,6 +38,8 @@ public enum TokenType
 
     /// <summary>The token type is a Fauna string.</summary>
     String,
+    /// <summary>The token type is a Fauna byte array.</summary>
+    Bytes,
 
     /// <summary>The token type is a Fauna integer.</summary>
     Int,
@@ -94,9 +96,8 @@ public static class TokenTypeExtensions
 
             case TokenType.String:
                 return FaunaType.String;
-            // BUG: @bytes support is missing; BT-5183
-            // case TokenType.Bytes:
-            //     return FaunaType.Bytes;
+            case TokenType.Bytes:
+                return FaunaType.Bytes;
             case TokenType.Int:
                 return FaunaType.Int;
             case TokenType.Long:

--- a/Fauna/Serialization/Utf8FaunaReader.cs
+++ b/Fauna/Serialization/Utf8FaunaReader.cs
@@ -170,6 +170,7 @@ public ref struct Utf8FaunaReader
             TokenType.Time => GetTime(),
             TokenType.True or TokenType.False => GetBoolean(),
             TokenType.Module => GetModule(),
+            TokenType.Bytes => GetBytes(),
             _ => throw new SerializationException($"{CurrentTokenType} does not have an associated value")
         };
     }
@@ -298,6 +299,24 @@ public ref struct Utf8FaunaReader
         catch (Exception e)
         {
             throw new SerializationException($"Failed to get byte from {_taggedTokenValue}", e);
+        }
+    }
+
+    /// <summary>
+    /// Retrieves a byte array value from the current token.
+    /// </summary>
+    /// <returns>A byte array representation of the current token's value.</returns>
+    public byte[] GetBytes()
+    {
+        ValidateTaggedTypes(TokenType.Bytes);
+
+        try
+        {
+            return Convert.FromBase64String(_taggedTokenValue!);
+        }
+        catch (Exception e)
+        {
+            throw new SerializationException($"Failed to get byte array from {_taggedTokenValue}", e);
         }
     }
 
@@ -583,6 +602,9 @@ public ref struct Utf8FaunaReader
                         break;
                     case "@time":
                         HandleTaggedString(TokenType.Time);
+                        break;
+                    case "@bytes":
+                        HandleTaggedString(TokenType.Bytes);
                         break;
                     default:
                         _bufferedTokenType = TokenType.FieldName;

--- a/Fauna/Serialization/Utf8FaunaWriter.cs
+++ b/Fauna/Serialization/Utf8FaunaWriter.cs
@@ -178,6 +178,17 @@ public sealed class Utf8FaunaWriter : IAsyncDisposable, IDisposable
     }
 
     /// <summary>
+    /// Writes a byte array value with a specific field name.
+    /// </summary>
+    /// <param name="fieldName">The name of the field.</param>
+    /// <param name="value">The byte array value to write.</param>
+    public void WriteBytes(string fieldName, byte[] value)
+    {
+        WriteFieldName(fieldName);
+        WriteBytesValue(value);
+    }
+
+    /// <summary>
     /// Writes a string value with a specific field name.
     /// </summary>
     /// <param name="fieldName">The name of the field.</param>
@@ -289,6 +300,15 @@ public sealed class Utf8FaunaWriter : IAsyncDisposable, IDisposable
     public void WriteIntValue(int value)
     {
         WriteTaggedValue("@int", value.ToString());
+    }
+
+    /// <summary>
+    /// Writes a byte array value as a tagged element.
+    /// </summary>
+    /// <param name="value">The byte array value to write.</param>
+    public void WriteBytesValue(byte[] value)
+    {
+        WriteTaggedValue("@bytes", Convert.ToBase64String(value));
     }
 
     /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
While working on a previous change, I noticed that we didn't have explicit support for the `@bytes` tag, so this adds it.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
See above.  Tracked in ticket BT-5183

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the code through new tests with `FAUNA_DEBUG=0`; all tests (including new ones) are green

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
