### PR TITLE
fix: Handle unmaterialize set endings in UTF8FaunaReader

### DIFF
--- a/Fauna.Test/Serialization/Utf8FaunaReader.Tests.cs
+++ b/Fauna.Test/Serialization/Utf8FaunaReader.Tests.cs
@@ -593,4 +593,30 @@ public class Utf8FaunaReaderTests
         Assert.AreEqual(TokenType.FieldName, reader.CurrentTokenType);
         Assert.AreEqual("k2", reader.GetString());
     }
+
+    [Test]
+    public void HandlesUnmaterializedSets()
+    {
+        const string test =
+            @"{""products"":{""@set"":""hdWCxmdQcm9kdWN0gcqEamJ5Q2F0ZWdvcnmBxmJ2MPT2gc1KBbkdRAugBgAEAvbBghpnGCOgGjW0K0AQ""},""name"":""foo""}";
+        var reader = new Utf8FaunaReader(test);
+        reader.Read(); // {
+        Assert.AreEqual(TokenType.StartObject, reader.CurrentTokenType);
+        reader.Read(); // "products"
+        Assert.AreEqual(TokenType.FieldName, reader.CurrentTokenType);
+        Assert.AreEqual("products", reader.GetString());
+        reader.Read(); // { "@set":
+        Assert.AreEqual(TokenType.StartPage, reader.CurrentTokenType);
+        reader.Read(); // "hdWCxmdQcm9kdWN0gcqEamJ5Q2F0ZWdvcnmBxmJ2MPT2gc1KBbkdRAugBgAEAvbBghpnGCOgGjW0K0AQ"
+        Assert.AreEqual("hdWCxmdQcm9kdWN0gcqEamJ5Q2F0ZWdvcnmBxmJ2MPT2gc1KBbkdRAugBgAEAvbBghpnGCOgGjW0K0AQ", reader.GetString());
+        reader.Read(); // "}"
+        Assert.AreEqual(TokenType.EndPage, reader.CurrentTokenType);
+        reader.Read(); // "name"
+        Assert.AreEqual(TokenType.FieldName, reader.CurrentTokenType);
+        Assert.AreEqual("name", reader.GetString());
+        reader.Read(); // "foo"
+        Assert.AreEqual("foo", reader.GetString());
+        reader.Read(); // "}"
+        Assert.AreEqual(TokenType.EndObject, reader.CurrentTokenType);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Handle unmaterialized set endings by tracking an internal token type on the stack and buffering the value
* Handle unmaterialized set tokens by buffering the value. This is the first case where we need to buffer a token that has an associated value. This implementation is naive, but that's intentional due to time constraints.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
BT-5260

Materialized and unmaterialized sets look slightly different on the wire. In the case of materialized sets, we encounter two end object json tokens that represent the end of the set. In the unmaterialized case, we only encounter one. When the reader encounters the unmaterialized set, it will cause the token stream to be shifted by one.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test covering the scenario.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [X] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
