### PR TITLE
[DOCS-3658] docs: Update CDC terminology in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,10 +292,11 @@ if (r.Data.Exists) {
 
 ## Event Streaming
 
-The driver supports [Event Streaming](https://docs.fauna.com/fauna/current/learn/track-changes/streaming/).
+The driver supports [Event Streaming](https://docs.fauna.com/fauna/current/learn/cdc/#event-streaming).
 
-To start and subscribe to an event stream, pass a
-query that produces a stream token to `EventStreamAsync()`:
+To start and subscribe to an Event Stream, pass a query that produces an [event
+source](https://docs.fauna.com/fauna/current/learn/cdc/#create-an-event-source)
+to `EventStreamAsync()`:
 
 ```csharp
 var stream = await client.EventStreamAsync<Person>(FQL($"Person.all().toStream"));
@@ -319,7 +320,7 @@ To enable debug logging, set the `FAUNA_DEBUG` environment variable to an intege
 
 The driver logs HTTP request and response details, including headers. For security, the `Authorization` header is redacted in debug logs but is visible in trace logs.
 
-> [!NOTE]  
+> [!NOTE]
 > As of v1.0.0, the driver only outputs `LogLevel.Debug` messages. Use `0` (Trace) or `1` (Debug) to log these messages.
 
 For advanced logging, you can use a custom `ILogger` implementation, such as Serilog or NLog. Pass the implementation to the `Configuration` class when instantiating a `Client`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
Updates the README's streaming section to use:

* New CDC terminology (`stream token` -> `event source`)
* New `eventSource()` and `eventsOn()` FQL methods

### Motivation and context
This aligns the README with the latest terminology in the docs and FQL.

### How was the change tested?
N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
