### PR TITLE
[DOCS-3362] docs: Fix typo in streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ source](https://docs.fauna.com/fauna/current/learn/cdc/#create-an-event-source)
 to `EventStreamAsync()`:
 
 ```csharp
-var stream = await client.EventStreamAsync<Person>(FQL($"Person.all().toStream"));
+var stream = await client.EventStreamAsync<Person>(FQL($"Person.all().eventSource()"));
 await foreach (var evt in stream)
 {
     Console.WriteLine($"Received Event Type: {evt.Type}");


### PR DESCRIPTION
### Description
Fixes a typo in the README's Event Streaming example.

### Motivation and context
- `toStream()` is deprecated and has been replaced by `eventSource()`
- The current example is missing parentheses and is invalid

### How was the change tested?
Tested locally.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
