### PR TITLE
chore(client): Add support for query timeout buffer (port from JVM)

### DIFF
--- a/Fauna.Test/Configuration.Tests.cs
+++ b/Fauna.Test/Configuration.Tests.cs
@@ -13,6 +13,7 @@ public class ConfigurationTests
 
         Assert.AreEqual("secret", b.Secret);
         Assert.AreEqual(Endpoints.Default, b.Endpoint);
+        Assert.AreEqual(TimeSpan.FromSeconds(5), b.DefaultQueryOptions.QueryTimeout);
         Assert.IsTrue(b.DisposeHttpClient);
     }
 
@@ -83,13 +84,13 @@ public class ConfigurationTests
         var defaults = new QueryOptions
         {
             TypeCheck = true,
-            QueryTags = new Dictionary<string, string> { { "foo", "bar" }, { "baz", "luhrmann" } },
-            QueryTimeout = TimeSpan.FromSeconds(30)
+            QueryTags = new Dictionary<string, string> { { "foo", "bar" }, { "baz", "luhrmann" } }
         };
         var overrides = new QueryOptions
         {
             Linearized = true,
-            QueryTags = new Dictionary<string, string> { { "foo", "yep" } }
+            QueryTags = new Dictionary<string, string> { { "foo", "yep" } },
+            QueryTimeout = TimeSpan.FromSeconds(30)
         };
 
         var finalOptions = QueryOptions.GetFinalQueryOptions(defaults, overrides);
@@ -101,5 +102,6 @@ public class ConfigurationTests
         Assert.IsNotNull(finalOptions!.QueryTags);
         Assert.AreEqual("yep", finalOptions!.QueryTags!["foo"]);
         Assert.AreEqual("luhrmann", finalOptions!.QueryTags!["baz"]);
+        Assert.AreEqual(TimeSpan.FromSeconds(30), finalOptions!.QueryTimeout);
     }
 }

--- a/Fauna/Configuration.cs
+++ b/Fauna/Configuration.cs
@@ -16,9 +16,15 @@ public record class Configuration
     public bool DisposeHttpClient { get; } = true;
 
     /// <summary>
+    /// Additional buffer to add to <see cref="QueryOptions.QueryTimeout"/> when setting the HTTP request
+    /// timeout on the <see cref="HttpClient"/>; default is 5 seconds.
+    /// </summary>
+    public TimeSpan ClientBufferTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
     /// The HTTP Client to use for requests.
     /// </summary>
-    public HttpClient HttpClient { get; } = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+    public HttpClient HttpClient { get; init; }
 
     /// <summary>
     /// The secret key used for authentication.
@@ -33,7 +39,7 @@ public record class Configuration
     /// <summary>
     /// Default options for queries sent to Fauna.
     /// </summary>
-    public QueryOptions? DefaultQueryOptions { get; init; } = null;
+    public QueryOptions DefaultQueryOptions { get; init; } = new();
 
     /// <summary>
     /// The retry configuration to apply to requests.
@@ -67,6 +73,11 @@ public record class Configuration
         {
             HttpClient = httpClient;
             DisposeHttpClient = false;
+        }
+        else
+        {
+            // Set Timeout to int.MaxValue milliseconds and configure each SendAsync with a timebound CancellationToken
+            HttpClient = new HttpClient { Timeout = TimeSpan.FromMilliseconds(int.MaxValue) };
         }
 
         if (logger != null)

--- a/Fauna/Configuration.cs
+++ b/Fauna/Configuration.cs
@@ -1,4 +1,5 @@
-﻿using Fauna.Core;
+﻿using System.Threading;
+using Fauna.Core;
 using Fauna.Util;
 using Microsoft.Extensions.Logging;
 
@@ -76,8 +77,7 @@ public record class Configuration
         }
         else
         {
-            // Set Timeout to int.MaxValue milliseconds and configure each SendAsync with a timebound CancellationToken
-            HttpClient = new HttpClient { Timeout = TimeSpan.FromMilliseconds(int.MaxValue) };
+            HttpClient = new HttpClient { Timeout = Timeout.InfiniteTimeSpan };
         }
 
         if (logger != null)

--- a/Fauna/Core/IConnection.cs
+++ b/Fauna/Core/IConnection.cs
@@ -15,12 +15,14 @@ internal interface IConnection : IDisposable
     /// <param name="path">The path of the resource to send the request to.</param>
     /// <param name="body">The stream containing the request body.</param>
     /// <param name="headers">A dictionary of headers to be included in the request.</param>
+    /// <param name="requestTimeout">The HTTP request timeout</param>
     /// <param name="cancel">A cancellation token to use with the request.</param>
     /// <returns>A Task representing the asynchronous operation, which upon completion contains the response from the server as <see cref="HttpResponseMessage"/>.</returns>
     Task<HttpResponseMessage> DoPostAsync(
         string path,
         Stream body,
         Dictionary<string, string> headers,
+        TimeSpan requestTimeout,
         CancellationToken cancel);
 
     /// <summary>

--- a/Fauna/Core/QueryOptions.cs
+++ b/Fauna/Core/QueryOptions.cs
@@ -17,8 +17,9 @@ public class QueryOptions
 
     /// <summary>
     /// Gets or sets the query timeout. It defines how long the client waits for a query to complete.
+    /// Default value is 5 seconds.
     /// </summary>
-    public TimeSpan? QueryTimeout { get; set; } = null;
+    public TimeSpan QueryTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Gets or sets a string-encoded set of caller-defined tags for identifying the request in logs and response bodies. 
@@ -37,19 +38,8 @@ public class QueryOptions
     /// <param name="options">The default query options.</param>
     /// <param name="overrides">The query options provided for a specific query, overriding the defaults.</param>
     /// <returns>A <see cref="QueryOptions"/> object representing the final combined set of query options.</returns>
-    internal static QueryOptions? GetFinalQueryOptions(QueryOptions? options, QueryOptions? overrides)
+    internal static QueryOptions GetFinalQueryOptions(QueryOptions options, QueryOptions? overrides)
     {
-
-        if (options == null && overrides == null)
-        {
-            return null;
-        }
-
-        if (options == null)
-        {
-            return overrides;
-        }
-
         if (overrides == null)
         {
             return options;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
To date the `HttpClient.Timeout` was set to 5 seconds, which could be overridden when instantiating the `HttpClient`, but it was clunky to override after the fact.  Upon realizing this, I noticed that we lacked support for a `queryTimeoutBuffer` that we have in other drivers, where the HTTP request timeout is actually the sum of the `queryTimeoutMs` for the given query plus a `queryTimeoutBuffer` that defaults to 5 seconds, so the default case would be 10 seconds total.  This PR adds that.

I'll grant that the way we configure the Fauna `Client` and the `HttpClient` is a little convoluted, so this PR attempts to make it work as is, but maybe a refactor would make the interface a little clearer.  I'm open to feedback on that.

NB: This is a slightly breaking change because it does change the signature of `IConnection.DoPostAsync`, but I rather doubt anyone is consuming that API directly in their apps.  Still, FYI.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
BT-5264

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and updated automation; I was starting to add more tests, but got hung up on exactly how to test it.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [x] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
