### PR TITLE
chore: Fix Doxygen warnings

### DIFF
--- a/Fauna/Core/StreamOptions.cs
+++ b/Fauna/Core/StreamOptions.cs
@@ -1,16 +1,16 @@
 namespace Fauna;
 
 /// <summary>
-/// Represents the options when subscribing to Fauna Streams.
+/// Represents the options when subscribing to Fauna Event Streams.
 /// </summary>
 public class StreamOptions
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="StreamOptions"/> class with the specified token and cursor.
     /// </summary>
-    /// <param name="token">The token returned from Fauna when the stream is created.</param>
+    /// <param name="token">The token for a Fauna event source.</param>
     /// <param name="cursor">The cursor from the stream, must be used with the associated Token. Used to resume the stream.</param>
-    /// <seealso href="https://docs.fauna.com/fauna/current/reference/streaming/#restart-a-stream"/>
+    /// See <a href="https://docs.fauna.com/fauna/current/reference/cdc/#restart">Restart an Event Stream</a>.
     public StreamOptions(string token, string cursor)
     {
         Token = token;
@@ -20,7 +20,7 @@ public class StreamOptions
     /// <summary>
     /// Initializes a new instance of the <see cref="StreamOptions"/> class with the specified token and start timestamp.
     /// </summary>
-    /// <param name="token">The token returned from Fauna when the stream is created.</param>
+    /// <param name="token">The token for a Fauna event source.</param>
     /// <param name="startTs">The start timestamp to use for the stream.</param>
     public StreamOptions(string token, long startTs)
     {
@@ -28,15 +28,16 @@ public class StreamOptions
         StartTs = startTs;
     }
 
-    // <summary>Token returned from Fauna when the stream is created.</summary>
-    /// <see href="https://docs.fauna.com/fauna/current/reference/http/reference/stream/get/"/>
+    /// <summary>Token for a Fauna event source.</summary>
+    /// See the <a
+    /// href="https://docs.fauna.com/fauna/current/reference/cdc/#event-source">Create an event source</a>.
     public string? Token { get; }
 
     /// <summary>Cursor from the stream, must be used with the associated Token. Used to resume the stream.</summary>
-    /// <see href="https://docs.fauna.com/fauna/current/reference/streaming/#restart-a-stream"/>
+    /// See <a href="https://docs.fauna.com/fauna/current/reference/cdc/#restart-cursor">Restart from an event cursor</a>.
     public string? Cursor { get; }
 
-    // <summary>Start timestamp from the stream, must be used with the associated Token. Used to resume the stream.</summary>
-    /// <see href="https://docs.fauna.com/fauna/current/reference/streaming/#restart-a-stream"/>
+    /// <summary>Start timestamp from the stream, must be used with the associated Token. Used to resume the stream.</summary>
+    /// See <a href="https://docs.fauna.com/fauna/current/reference/cdc/#restart-txn-ts">Restart from a transaction timestamp</a>.
     public long? StartTs { get; }
 }

--- a/Fauna/Types/Module.cs
+++ b/Fauna/Types/Module.cs
@@ -2,7 +2,7 @@ namespace Fauna.Types;
 
 /// <summary>
 /// Represents a module, a singleton object grouping related functionalities.
-/// Modules are serialized as @mod values in tagged formats, organizing and encapsulating specific functionalities.
+/// Modules are serialized as \@mod values in tagged formats, organizing and encapsulating specific functionalities.
 /// </summary>
 public sealed class Module : IEquatable<Module>
 {


### PR DESCRIPTION
### Description
* Fixes some Doxygen warnings
* Updates several links to the CDC docs

### Motivation and context
[DOCS-3671](https://faunadb.atlassian.net/browse/DOCS-3671)

Currently, Doxygen is just dropping the syntax from these warnings.

### How was the change tested?

Ran Doxygen locally.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[DOCS-3671]: https://faunadb.atlassian.net/browse/DOCS-3671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ