### PR TITLE
feat(platform-tests): Add 3rd-party platform testing to the release pipeline

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -149,28 +149,19 @@ jobs:
         reveal: true
         file: repo.git/.git/ref
 
-      - in_parallel:
-          fail_fast: false
-          steps:
-            # - task: validate-aws-lambda
-            #   image: testtools-image-dotnet
-            #   file: testtools-repo/fauna-driver-platform-tests/concourse/tasks/dotnet-aws-lambda-tests.yml
-            #   params:
-            #     <<: [*shared-params, *aws-lambda-params]
-
-            - task: validate-azure-functions-net80
-              image: testtools-image-dotnet
-              file: testtools-repo/fauna-driver-platform-tests/concourse/tasks/dotnet-azure-tests.yml
-              params:
-                APP_ID: ((drivers-platform-tests/azure-app-id))
-                FAUNA_DOTNET: repo.git
-                FAUNA_SECRET: ((drivers-platform-tests/fauna-secret))
-                FUNC_NAME_PREFIX: fql-az-functions-
-                GIT_COMMIT: ((.:git-commit))
-                NET_VERSION: 8
-                PASSWORD: ((drivers-platform-tests/azure-app-password))
-                RG_NAME: FqlAzureFunctions-rg
-                TENANT_ID: ((drivers-platform-tests/azure-tenant-id))
+      - task: validate-azure-functions-net80
+        image: testtools-image-dotnet
+        file: testtools-repo/fauna-driver-platform-tests/concourse/tasks/dotnet-azure-tests.yml
+        params:
+          APP_ID: ((drivers-platform-tests/azure-app-id))
+          FAUNA_DOTNET: repo.git
+          FAUNA_SECRET: ((drivers-platform-tests/fauna-secret))
+          FUNC_NAME_PREFIX: fql-az-functions-
+          GIT_COMMIT: ((.:git-commit))
+          NET_VERSION: 8
+          PASSWORD: ((drivers-platform-tests/azure-app-password))
+          RG_NAME: FqlAzureFunctions-rg
+          TENANT_ID: ((drivers-platform-tests/azure-tenant-id))
 
   - name: release
     serial: true

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -5,6 +5,16 @@ resource_types:
     source:
       repository: cfcommunity/slack-notification-resource
 
+  - name: buildx-resource
+    type: registry-image
+    privileged: true
+    source:
+      repository: shared-concourse-buildx
+      aws_access_key_id: ((prod-images-aws-access-key-id))
+      aws_secret_access_key: ((prod-images-aws-secret-key))
+      aws_region: us-east-2
+      tag: latest
+
 resources:
   - name: self-config
     type: git
@@ -41,6 +51,42 @@ resources:
       branch: gh-pages
       private_key: ((github-ssh-key))
 
+  - name: testtools-repo
+    type: git
+    icon: github
+    source:
+      uri: git@github.com:fauna/testtools.git
+      branch: main
+      private_key: ((github-ssh-key))
+
+  - name: testtools-deps-repo
+    type: git
+    icon: github
+    source:
+      uri: git@github.com:fauna/testtools.git
+      branch: main
+      private_key: ((github-ssh-key))
+      paths:
+        - fauna-driver-platform-tests/package.json
+        - fauna-driver-platform-tests/Dockerfile.dotnet
+
+  - name: testtools-image-dotnet
+    type: registry-image
+    icon: docker
+    source:
+      repository: devex-dotnet-driver-platform-tests
+      aws_access_key_id: ((prod-images-aws-access-key-id))
+      aws_secret_access_key: ((prod-images-aws-secret-key))
+      aws_region: us-east-2
+
+  - name: build-and-publish-dotnet
+    type: buildx-resource
+    source:
+      repo: ((prod-images-repo-url))/devex-dotnet-driver-platform-tests
+      aws_access_key_id: ((prod-images-aws-access-key-id))
+      aws_secret_access_key: ((prod-images-aws-secret-key))
+    icon: docker
+
   - name: dev-tests-trigger
     type: time
     source:
@@ -54,6 +100,20 @@ jobs:
 
       - set_pipeline: self
         file: self-config/concourse/pipeline.yml
+
+  - name: build-image
+    serial: true
+    plan:
+      - get: testtools-deps-repo
+        trigger: true
+
+      - put: build-and-publish-dotnet
+        inputs:
+          - testtools-deps-repo
+        params:
+          dir: testtools-deps-repo/fauna-driver-platform-tests/
+          dockerfile: testtools-deps-repo/fauna-driver-platform-tests/Dockerfile.dotnet
+          tag: latest
 
   - name: perf-tests-dev
     serial: true
@@ -76,11 +136,48 @@ jobs:
           params:
             text_file: slack-message/perf-stats
 
+  - name: test
+    serial: true
+    plan:
+      - get: repo.git
+        trigger: true
+
+      - get: testtools-repo
+      - get: testtools-image-dotnet
+
+      - load_var: git-commit
+        reveal: true
+        file: repo.git/.git/ref
+
+      - in_parallel:
+          fail_fast: false
+          steps:
+            # - task: validate-aws-lambda
+            #   image: testtools-image-dotnet
+            #   file: testtools-repo/fauna-driver-platform-tests/concourse/tasks/dotnet-aws-lambda-tests.yml
+            #   params:
+            #     <<: [*shared-params, *aws-lambda-params]
+
+            - task: validate-azure-functions-net80
+              image: testtools-image-dotnet
+              file: testtools-repo/fauna-driver-platform-tests/concourse/tasks/dotnet-azure-tests.yml
+              params:
+                APP_ID: ((drivers-platform-tests/azure-app-id))
+                FAUNA_DOTNET: repo.git
+                FAUNA_SECRET: ((drivers-platform-tests/fauna-secret))
+                FUNC_NAME_PREFIX: fql-az-functions-
+                GIT_COMMIT: ((.:git-commit))
+                NET_VERSION: 8
+                PASSWORD: ((drivers-platform-tests/azure-app-password))
+                RG_NAME: FqlAzureFunctions-rg
+                TENANT_ID: ((drivers-platform-tests/azure-tenant-id))
+
   - name: release
     serial: true
     public: false
     plan:
       - get: repo.git
+        passed: [ test ]
       - get: docs.git
 
       - task: publish


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
This PR adds support for validating the .NET driver in Azure Functions to ensure that a release build doesn't break one of the most popular 3rd-party platform that .NET customers would likely use for serverless functions.

The pipeline references a private repo, `fauna/testtools`, which just contains a simple Hello World app and the script collateral needed to publish the Azure Function app.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
BT-4442

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the setup scripts, test case, and Dockerfile build locally against real Azure; the image build part of the pipeline may require some iteration.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
