### PR TITLE
chore: Remove official net6.0 support

### DIFF
--- a/.github/workflows/pr_validate.yml
+++ b/.github/workflows/pr_validate.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        dotnet-version: [ '6.0.x', '8.0.x' ]
+        dotnet-version: [ '8.0.x' ]
 
     services:
       fauna:

--- a/Fauna.Test/Fauna.Test.csproj
+++ b/Fauna.Test/Fauna.Test.csproj
@@ -31,7 +31,7 @@
     <Folder Include="Types\" />
   </ItemGroup>
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Fauna/Fauna.csproj
+++ b/Fauna/Fauna.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>0.5.0-beta</Version>
     <PackageId>Fauna</PackageId>
     <Title>.NET Driver for Fauna</Title>

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ See the [Fauna Documentation](https://docs.fauna.com/fauna/current/) for additio
 ## Compatibility
 
 - C# ^10.0
-- .NET 6.0
-- .NET 7.0
 - .NET 8.0
 
 ## Installation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
As discussed, we're removing `net6.0` support as it is coming out of official Microsoft support in just a few days from this PR: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
BT-5277

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built the project and ran automation; no other changes

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [x] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
