### PR TITLE
chore(platform-tests): Build Dockerfile.dotnet in only amd64

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -113,6 +113,7 @@ jobs:
         params:
           dir: testtools-deps-repo/fauna-driver-platform-tests/
           dockerfile: testtools-deps-repo/fauna-driver-platform-tests/Dockerfile.dotnet
+          build_platform: linux/amd64
           tag: latest
 
   - name: perf-tests-dev


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
The Azure Function tools only build on amd64 (🤦), so I need to skip the arm64 build; fortunately (but not before several hours not realizing this fact), our Concourse workers are Intel-based, so amd64 is all we need for now.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
BT-5290

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I had already been able to build amd64 locally and in the pipeline; this just removes the arm64 build.

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
