### PR TITLE
feat: Add Processing Time stat field

### DIFF
--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -649,10 +649,8 @@ public class IntegrationTests
         int pages = 0;
         await foreach (var page in feed)
         {
-            if (page.HasNext)
-            {
-                Assert.AreEqual(pageSize, page.Events.Count);
-            }
+            if (page.Events.Count > 0) Assert.NotNull(page.Events[0].Stats.ProcessingTimeMs);
+            if (page.HasNext) Assert.AreEqual(pageSize, page.Events.Count);
 
             pages++;
         }

--- a/Fauna/Core/QueryStats.cs
+++ b/Fauna/Core/QueryStats.cs
@@ -57,6 +57,12 @@ public readonly struct QueryStats
     public List<string> RateLimitsHit { get; init; }
 
     /// <summary>
+    /// Processing time in milliseconds, only returned on Events.
+    /// </summary>
+    [JsonPropertyName(Stats_ProcessingTimeMs)]
+    public int? ProcessingTimeMs { get; init; }
+
+    /// <summary>
     /// Returns a string representation of the query statistics.
     /// </summary>
     /// <returns>A string detailing the query execution statistics.</returns>
@@ -65,6 +71,7 @@ public readonly struct QueryStats
         return $"compute: {ComputeOps}, read: {ReadOps}, write: {WriteOps}, " +
                $"queryTime: {QueryTimeMs}, retries: {ContentionRetries}, " +
                $"storageRead: {StorageBytesRead}, storageWrite: {StorageBytesWrite}, " +
+               $"{(ProcessingTimeMs.HasValue ? $"processingTime: {ProcessingTimeMs}, " : "")}" +
                $"limits: [{string.Join(',', RateLimitsHit)}]";
     }
 }

--- a/Fauna/Core/QueryStats.cs
+++ b/Fauna/Core/QueryStats.cs
@@ -57,7 +57,7 @@ public readonly struct QueryStats
     public List<string> RateLimitsHit { get; init; }
 
     /// <summary>
-    /// Processing time in milliseconds, only returned on Events.
+    /// Processing time in milliseconds. Only returned on Events.
     /// </summary>
     [JsonPropertyName(Stats_ProcessingTimeMs)]
     public int? ProcessingTimeMs { get; init; }

--- a/Fauna/Core/ResponseFields.cs
+++ b/Fauna/Core/ResponseFields.cs
@@ -106,6 +106,11 @@ internal readonly struct ResponseFields
     /// </summary>
     public const string Stats_RateLimitsHit = "rate_limits_hit";
 
+    /// <summary>
+    /// Field name for the processing time in milliseconds.
+    /// </summary>
+    public const string Stats_ProcessingTimeMs = "processing_time_ms";
+
     #endregion
 
     #region "error" block


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
BT-4680

### Description

Add support for the `processing_time_ms` stat returned on Events

### Motivation and context

Include all available Stats

### How was the change tested?

Updated integ test

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
