### PR TITLE
fix: Remove NextAsync from FeedEnumerable

### DIFF
--- a/Fauna.Test/Integration.Tests.cs
+++ b/Fauna.Test/Integration.Tests.cs
@@ -549,7 +549,8 @@ public class IntegrationTests
         Assert.IsNotEmpty(feed.Cursor, "should have a cursor");
         Assert.IsNull(feed.CurrentPage, "should not have loaded a page");
 
-        await feed.NextAsync();
+        await using IAsyncEnumerator<FeedPage<StreamingSandbox>> asyncEnumerator = feed.GetAsyncEnumerator();
+        await asyncEnumerator.MoveNextAsync();
 
         Assert.NotNull(feed.CurrentPage, "should have loaded a page");
         Assert.IsNotEmpty(feed.Cursor, "should have a cursor");
@@ -567,8 +568,8 @@ public class IntegrationTests
             lastPage = page;
         }
 
-        // Get another page, should be empty
-        await feed.NextAsync();
+        await using IAsyncEnumerator<FeedPage<StreamingSandbox>> asyncEnumeratorAgain = feed.GetAsyncEnumerator();
+        await asyncEnumeratorAgain.MoveNextAsync();
 
         Assert.IsEmpty(feed.CurrentPage!.Events, "should not have any events");
         if (lastPage != null)
@@ -587,7 +588,8 @@ public class IntegrationTests
         var feed = await _client.EventFeedAsync<StreamingSandbox>(eventSource);
         Assert.IsNotNull(feed);
 
-        await feed.NextAsync();
+        await using IAsyncEnumerator<FeedPage<StreamingSandbox>> asyncEnumerator = feed.GetAsyncEnumerator();
+        await asyncEnumerator.MoveNextAsync();
 
         Assert.IsNotEmpty(feed.Cursor, "should have a cursor");
         Assert.IsEmpty(feed.CurrentPage!.Events, "should not have any events");

--- a/Fauna/Core/FeedEnumerable.cs
+++ b/Fauna/Core/FeedEnumerable.cs
@@ -34,26 +34,6 @@ public class FeedEnumerable<T> where T : notnull
     }
 
     /// <summary>
-    /// Move to the next page of the Event Feed.
-    /// </summary>
-    /// <returns></returns>
-    public async Task<bool> NextAsync()
-    {
-        await using var subscribeFeed = _client.SubscribeFeed<T>(
-            _eventSource,
-            _client.MappingCtx,
-            _cancel);
-
-        bool result = await subscribeFeed.MoveNextAsync();
-        if (result)
-        {
-            CurrentPage = subscribeFeed.Current;
-        }
-
-        return result;
-    }
-
-    /// <summary>
     /// Returns an enumerator that iterates through the Feed.
     /// </summary>
     /// <returns>Event Page Enumerator</returns>

--- a/README.md
+++ b/README.md
@@ -319,9 +319,8 @@ var feed = await client.EventFeedAsync<Person>(eventSource, feedOptions);
 var feedFromQuery = await client.EventFeedAsync<Person>(FQL($"Person.all().eventsOn({{ .price, .stock }})"), feedOptions);
 
 // EventFeedAsync() returns a `FeedEnumerable` instance that can act as an `AsyncEnumerator`.
-// Use `foreach()` or `NextAsync()` to iterate through the pages of events.
+// Use `foreach()` to iterate through the pages of events.
 
-// Example 1: Use `foreach()` to iterate through feed pages.
 await foreach (var page in feed)
 {
     foreach (var evt in page.Events)
@@ -331,24 +330,6 @@ await foreach (var page in feed)
         Console.WriteLine($"First Name: {person.FirstName} - Last Name: {person.LastName} - Age: {person.Age}");
     }
 }
-
-// Example 2: Use `NextAsync()` to manually iterate through feed pages.
-// `NextAsync()` requests the next page:
-await feed.NextAsync();
-
-if (feedFromQuery.CurrentPage != null && feedFromQuery.CurrentPage.Events.Any())
-{
-    foreach (var evt in feedFromQuery.CurrentPage.Events)
-    {
-        Console.WriteLine($"Event Type: {evt.Type}");
-        Person person = evt.Data;
-        Console.WriteLine($"First Name: {person.FirstName} - Last Name: {person.LastName} - Age: {person.Age}");
-    }
-}
-
-// Call `NextAsync()` again to fetch the next page:
-await feed.NextAsync();
-```
 
 ## Event Streaming
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description

- Remove the `NextAsync` method from the `FeedEnumerable`
- Fix typo on the file name

### Motivation and context

A few consumers have stubbed their toe on this method appearing to something that can be used in a `while`. We don't need it as consumers can manually step through the enumerator returned from `GetAsyncEnumerator` if they so choose. 

### How was the change tested?

Validated integ tests

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
