### PR TITLE
Handle unmaterialized sets in PageSerializer

### DIFF
--- a/Fauna.Test/Serialization/Serializers/PageSerializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializers/PageSerializer.Tests.cs
@@ -64,4 +64,16 @@ public class PageSerializer_Tests
         Assert.AreEqual(40, deserialized.Data[1].Age);
         Assert.AreEqual("next_page_cursor", deserialized.After);
     }
+
+    [Test]
+    public void DeserializeUnmaterializedSet()
+    {
+        const string token = "aftertoken";
+        const string wire = $$"""{"@set":"{{token}}"}""";
+
+        var serializer = Serializer.Generate<Page<object>>(s_ctx);
+        var deserialized = Helpers.Deserialize(serializer, s_ctx, wire)!;
+        Assert.IsEmpty(deserialized.Data);
+        Assert.AreEqual(token, deserialized.After);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
* Handle unmaterialized sets in the PageSerializer

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
BT-5310

While we fixed handling these at the token level, I forgot to fix the PageSerializer as well. This caused unmaterialized sets to throw in cryptic ways.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [X] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
