### PR TITLE
Handle event sources in DynamicSerializer

### DIFF
--- a/Fauna.Test/Serialization/Serializers/DynamicSerializer.Tests.cs
+++ b/Fauna.Test/Serialization/Serializers/DynamicSerializer.Tests.cs
@@ -191,4 +191,26 @@ public class DynamicSerializerTests
         string serialized = Helpers.Serialize(Serializer.Dynamic, _ctx, deserialized);
         Assert.AreEqual("{\"@ref\":{\"id\":\"123\",\"coll\":{\"@mod\":\"MappedColl\"}}}", serialized);
     }
+
+    [Test]
+    public void RoundTripEventSource()
+    {
+        const string wire = """{"@stream":"test123="}""";
+        object? deserialized = Helpers.Deserialize(Serializer.Dynamic, _ctx, wire);
+        switch (deserialized)
+        {
+            case EventSource e:
+                Assert.AreEqual("test123=", e.Token);
+                Assert.IsNull(e.Options.Cursor);
+                Assert.IsNull(e.Options.StartTs);
+                Assert.IsNull(e.Options.PageSize);
+                break;
+            default:
+                Assert.Fail($"result is type: {deserialized?.GetType()}");
+                break;
+        }
+
+        // We do not support encoding EventSources
+        Assert.Throws<NotImplementedException>(() => Helpers.Serialize(Serializer.Dynamic, _ctx, deserialized));
+    }
 }

--- a/Fauna/Serialization/DynamicSerializer.cs
+++ b/Fauna/Serialization/DynamicSerializer.cs
@@ -59,6 +59,7 @@ internal class DynamicSerializer : BaseSerializer<object?>
             TokenType.Module => reader.GetModule(),
             TokenType.Bytes => reader.GetBytes(),
             TokenType.Null => null,
+            TokenType.EventSource => reader.GetEventSource(),
             _ => throw new SerializationException(
                 $"Unexpected token while deserializing: {reader.CurrentTokenType}"),
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
Handle event source deserialization with the DynamicSerializer

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
BT-5312

If you request an event source from Fauna without specifying a return type, we use the DynamicSerializer to deserialize the results. In this case, we encountered an unsupported token exception.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [X] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
