### PR TITLE
[DOCS-3753] Event Feeds: Document `pageSize` limit

### DIFF
--- a/Fauna/Core/FeedOptions.cs
+++ b/Fauna/Core/FeedOptions.cs
@@ -11,7 +11,8 @@ public class FeedOptions : EventOptions
     /// Initializes a new instance of the <see cref="FeedOptions"/> class with the specified cursor and optional page size.
     /// </summary>
     /// <param name="cursor">The cursor for the feed. Used to resume the Feed.</param>
-    /// <param name="pageSize">Optional page size for the feed.</param>
+    /// <param name="pageSize">Optional page size for the feed. Sets the maximum number of events returned per page. Must
+    /// be in the range 1 to 16000 (inclusive). Defaults to 16.</param>
     /// <seealso href="https://docs.fauna.com/fauna/current/reference/cdc/#get-events-after-a-specific-cursor"/>
     public FeedOptions(string cursor, int? pageSize = null)
     {
@@ -23,7 +24,8 @@ public class FeedOptions : EventOptions
     /// Initializes a new instance of the <see cref="FeedOptions"/> class with the specified start timestamp and optional page size.
     /// </summary>
     /// <param name="startTs">The start timestamp for the feed. Used to resume the Feed.</param>
-    /// <param name="pageSize">Optional page size for the feed.</param>
+    /// <param name="pageSize">Optional page size for the feed. Sets the maximum number of events returned per page. Must
+    /// be in the range 1 to 16000 (inclusive). Defaults to 16.</param>
     /// <seealso href="https://docs.fauna.com/fauna/current/reference/cdc/#get-events-after-a-specific-cursor"/>
     public FeedOptions(long startTs, int? pageSize = null)
     {
@@ -34,7 +36,8 @@ public class FeedOptions : EventOptions
     /// <summary>
     /// Initializes a new instance of the <see cref="FeedOptions"/> class with the specified page size.
     /// </summary>
-    /// <param name="pageSize">The page size for the feed.</param>
+    /// <param name="pageSize">Maximum number of events returned per page. Must
+    /// be in the range 1 to 16000 (inclusive). Defaults to 16.</param>
     public FeedOptions(int pageSize)
     {
         PageSize = pageSize;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
Documents accepted range for `pageSize` in `FeedOptions`.

### Motivation and context
Keeps docs updated with changes in https://github.com/fauna/core/pull/12010.

### How was the change tested?
N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
